### PR TITLE
IS-2093: Add dokarkiv client + skeleton for journalforing of varsler

### DIFF
--- a/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/Cronjob.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/Cronjob.kt
@@ -1,0 +1,7 @@
+package no.nav.syfo.infrastructure.cronjob
+
+interface Cronjob {
+    suspend fun run()
+    val initialDelayMinutes: Long
+    val intervalDelayMinutes: Long
+}

--- a/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/CronjobResult.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/CronjobResult.kt
@@ -1,0 +1,6 @@
+package no.nav.syfo.infrastructure.cronjob
+
+data class CronjobResult(
+    var updated: Int = 0,
+    var failed: Int = 0
+)

--- a/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/JournalforForhandsvarselCronjob.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/JournalforForhandsvarselCronjob.kt
@@ -1,0 +1,38 @@
+package no.nav.syfo.infrastructure.cronjob
+
+import net.logstash.logback.argument.StructuredArguments
+import no.nav.syfo.infrastructure.dokarkiv.DokarkivClient
+import no.nav.syfo.infrastructure.pdl.PdlClient
+import org.slf4j.LoggerFactory
+
+class JournalforForhandsvarselCronjob(
+    private val dokarkivClient: DokarkivClient,
+    private val pdlClient: PdlClient,
+) : Cronjob {
+    override val initialDelayMinutes: Long = 2
+    override val intervalDelayMinutes: Long = 10
+
+    override suspend fun run() {
+        val result = runJob()
+        log.info(
+            "Completed journalføring of varsel with result: {}, {}",
+            StructuredArguments.keyValue("failed", result.failed),
+            StructuredArguments.keyValue("updated", result.updated),
+        )
+    }
+
+    fun runJob(): CronjobResult {
+        val result = CronjobResult()
+        // Hent ikke-journalførte forhåndsvarsler
+
+        // For alle ikke-journalførte forhåndsvarsler
+        // - Hent navn fra pdl
+        // - Journalfør
+        // - Registrer at forhåndsvarselet er journalført
+        return result
+    }
+
+    companion object {
+        private val log = LoggerFactory.getLogger(JournalforForhandsvarselCronjob::class.java)
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/infrastructure/dokarkiv/DokarkivClient.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/dokarkiv/DokarkivClient.kt
@@ -1,0 +1,103 @@
+package no.nav.syfo.infrastructure.dokarkiv
+
+import io.ktor.client.*
+import io.ktor.client.call.*
+import io.ktor.client.plugins.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import io.micrometer.core.instrument.Counter
+import net.logstash.logback.argument.StructuredArguments
+import no.nav.syfo.api.ClientEnvironment
+import no.nav.syfo.api.httpClientDefault
+import no.nav.syfo.infrastructure.azuread.AzureAdClient
+import no.nav.syfo.infrastructure.bearerHeader
+import no.nav.syfo.infrastructure.dokarkiv.dto.JournalpostRequest
+import no.nav.syfo.infrastructure.dokarkiv.dto.JournalpostResponse
+import no.nav.syfo.infrastructure.metric.METRICS_NS
+import no.nav.syfo.infrastructure.metric.METRICS_REGISTRY
+import org.slf4j.LoggerFactory
+
+class DokarkivClient(
+    private val azureAdClient: AzureAdClient,
+    private val dokarkivEnvironment: ClientEnvironment,
+    private val httpClient: HttpClient = httpClientDefault(),
+) {
+    private val journalpostUrl: String = "${dokarkivEnvironment.baseUrl}$JOURNALPOST_PATH"
+
+    suspend fun journalfor(
+        journalpostRequest: JournalpostRequest,
+    ): JournalpostResponse {
+        val token = azureAdClient.getSystemToken(dokarkivEnvironment.clientId)?.accessToken
+            ?: throw RuntimeException("Failed to Journalfor Journalpost: No token was found")
+        return try {
+            val response: HttpResponse = httpClient.post(journalpostUrl) {
+                parameter(JOURNALPOST_PARAM_STRING, JOURNALPOST_PARAM_VALUE)
+                header(HttpHeaders.Authorization, bearerHeader(token))
+                accept(ContentType.Application.Json)
+                contentType(ContentType.Application.Json)
+                setBody(journalpostRequest)
+            }
+            val journalpostResponse = response.body<JournalpostResponse>()
+            Metrics.COUNT_CALL_DOKARKIV_JOURNALPOST_SUCCESS.increment()
+            journalpostResponse
+        } catch (e: ClientRequestException) {
+            if (e.response.status == HttpStatusCode.Conflict) {
+                val journalpostResponse = e.response.body<JournalpostResponse>()
+                log.warn("Journalpost med id ${journalpostResponse.journalpostId} lagret fra før (409 Conflict)")
+                Metrics.COUNT_CALL_DOKARKIV_JOURNALPOST_CONFLICT.increment()
+                journalpostResponse
+            } else {
+                handleUnexpectedResponseException(e.response, e.message)
+                throw e
+            }
+        } catch (e: ServerResponseException) {
+            handleUnexpectedResponseException(e.response, e.message)
+            throw e
+        }
+    }
+
+    private fun handleUnexpectedResponseException(
+        response: HttpResponse,
+        message: String?,
+    ) {
+        log.error(
+            "Error while requesting Dokarkiv to Journalpost PDF with {}, {}",
+            StructuredArguments.keyValue("statusCode", response.status.value.toString()),
+            StructuredArguments.keyValue("message", message),
+        )
+        Metrics.COUNT_CALL_DOKARKIV_JOURNALPOST_FAIL.increment()
+    }
+
+    companion object {
+        private const val JOURNALPOST_PATH = "/rest/journalpostapi/v1/journalpost"
+        private const val JOURNALPOST_PARAM_STRING = "forsoekFerdigstill"
+        private const val JOURNALPOST_PARAM_VALUE = true
+        private val log = LoggerFactory.getLogger(DokarkivClient::class.java)
+    }
+}
+
+private class Metrics {
+    companion object {
+        const val CALL_DOKARKIV_BASE = "${METRICS_NS}_call_dokarkiv"
+
+        const val CALL_DOKARKIV_JOURNALPOST_BASE = "${CALL_DOKARKIV_BASE}_journalpost"
+        const val CALL_DOKARKIV_JOURNALPOST_SUCCESS = "${CALL_DOKARKIV_JOURNALPOST_BASE}_success_count"
+        const val CALL_DOKARKIV_JOURNALPOST_FAIL = "${CALL_DOKARKIV_JOURNALPOST_BASE}_fail_count"
+
+        val COUNT_CALL_DOKARKIV_JOURNALPOST_SUCCESS: Counter = Counter
+            .builder(CALL_DOKARKIV_JOURNALPOST_SUCCESS)
+            .description("Counts the number of successful calls to Dokarkiv - Journalpost")
+            .register(METRICS_REGISTRY)
+        val COUNT_CALL_DOKARKIV_JOURNALPOST_FAIL: Counter = Counter
+            .builder(CALL_DOKARKIV_JOURNALPOST_FAIL)
+            .description("Counts the number of failed calls to Dokarkiv - Journalpost")
+            .register(METRICS_REGISTRY)
+
+        const val CALL_DOKARKIV_JOURNALPOST_CONFLICT = "${CALL_DOKARKIV_JOURNALPOST_BASE}_conflict_count"
+        val COUNT_CALL_DOKARKIV_JOURNALPOST_CONFLICT: Counter = Counter
+            .builder(CALL_DOKARKIV_JOURNALPOST_CONFLICT)
+            .description("Counts the number of calls to Dokarkiv - Journalpost resulting in 409 Conflict")
+            .register(METRICS_REGISTRY)
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/infrastructure/dokarkiv/dto/AvsenderMottaker.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/dokarkiv/dto/AvsenderMottaker.kt
@@ -1,0 +1,19 @@
+package no.nav.syfo.infrastructure.dokarkiv.dto
+
+data class AvsenderMottaker private constructor(
+    val id: String?,
+    val idType: String?,
+    val navn: String? = null,
+) {
+    companion object {
+        fun create(
+            id: String?,
+            idType: BrukerIdType?,
+            navn: String? = null,
+        ) = AvsenderMottaker(
+            id = id,
+            idType = idType?.value,
+            navn = navn
+        )
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/infrastructure/dokarkiv/dto/Bruker.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/dokarkiv/dto/Bruker.kt
@@ -1,0 +1,22 @@
+package no.nav.syfo.infrastructure.dokarkiv.dto
+
+enum class BrukerIdType(
+    val value: String,
+) {
+    PERSON_IDENT("FNR"),
+}
+
+data class Bruker private constructor(
+    val id: String,
+    val idType: String,
+) {
+    companion object {
+        fun create(
+            id: String,
+            idType: BrukerIdType,
+        ) = Bruker(
+            id = id,
+            idType = idType.value
+        )
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/infrastructure/dokarkiv/dto/Dokument.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/dokarkiv/dto/Dokument.kt
@@ -1,0 +1,24 @@
+package no.nav.syfo.infrastructure.dokarkiv.dto
+
+enum class BrevkodeType(
+    val value: String,
+)
+
+data class Dokument private constructor(
+    val brevkode: String,
+    val dokumentKategori: String? = null,
+    val dokumentvarianter: List<Dokumentvariant>,
+    val tittel: String? = null,
+) {
+    companion object {
+        fun create(
+            brevkode: BrevkodeType,
+            dokumentvarianter: List<Dokumentvariant>,
+            tittel: String? = null,
+        ) = Dokument(
+            brevkode = brevkode.value,
+            dokumentvarianter = dokumentvarianter,
+            tittel = tittel,
+        )
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/infrastructure/dokarkiv/dto/DokumentInfo.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/dokarkiv/dto/DokumentInfo.kt
@@ -1,0 +1,7 @@
+package no.nav.syfo.infrastructure.dokarkiv.dto
+
+data class DokumentInfo(
+    val brevkode: String? = null,
+    val dokumentInfoId: Int? = null,
+    val tittel: String? = null,
+)

--- a/src/main/kotlin/no/nav/syfo/infrastructure/dokarkiv/dto/Dokumentvariant.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/dokarkiv/dto/Dokumentvariant.kt
@@ -1,0 +1,63 @@
+package no.nav.syfo.infrastructure.dokarkiv.dto
+
+enum class FiltypeType(
+    val value: String,
+) {
+    PDFA("PDFA"),
+}
+
+enum class VariantformatType(
+    val value: String,
+) {
+    ARKIV("ARKIV"),
+}
+
+const val DOKUMENTVARIANT_FILNAVN_MAX_LENGTH = 200
+
+data class Dokumentvariant private constructor(
+    val filnavn: String,
+    val filtype: String,
+    val fysiskDokument: ByteArray,
+    val variantformat: String,
+) {
+    companion object {
+        fun create(
+            filnavn: String,
+            filtype: FiltypeType,
+            fysiskDokument: ByteArray,
+            variantformat: VariantformatType,
+        ): Dokumentvariant {
+            if ((filnavn.length + filtype.value.length) >= DOKUMENTVARIANT_FILNAVN_MAX_LENGTH) {
+                throw IllegalArgumentException("Filnavn of Dokumentvariant is too long, max size is $DOKUMENTVARIANT_FILNAVN_MAX_LENGTH")
+            }
+            return Dokumentvariant(
+                filnavn = filnavn,
+                filtype = filtype.value,
+                fysiskDokument = fysiskDokument,
+                variantformat = variantformat.value,
+            )
+        }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as Dokumentvariant
+
+        if (filnavn != other.filnavn) return false
+        if (filtype != other.filtype) return false
+        if (!fysiskDokument.contentEquals(other.fysiskDokument)) return false
+        if (variantformat != other.variantformat) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = filnavn.hashCode()
+        result = 31 * result + filtype.hashCode()
+        result = 31 * result + fysiskDokument.contentHashCode()
+        result = 31 * result + variantformat.hashCode()
+        return result
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/infrastructure/dokarkiv/dto/JournalpostRequest.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/dokarkiv/dto/JournalpostRequest.kt
@@ -1,0 +1,25 @@
+package no.nav.syfo.infrastructure.dokarkiv.dto
+
+const val JOURNALFORENDE_ENHET = 9999
+
+enum class JournalpostType(val value: String) {
+    UTGAAENDE("UTGAAENDE"),
+}
+
+enum class JournalpostTema(val value: String) {
+    OPPFOLGING("OPP"),
+}
+
+data class JournalpostRequest(
+    val avsenderMottaker: AvsenderMottaker,
+    val tittel: String,
+    val bruker: Bruker? = null,
+    val dokumenter: List<Dokument>,
+    val journalfoerendeEnhet: Int? = JOURNALFORENDE_ENHET,
+    val journalpostType: String = JournalpostType.UTGAAENDE.value,
+    val tema: String = JournalpostTema.OPPFOLGING.value,
+    val kanal: String,
+    val sak: Sak = Sak(),
+    val eksternReferanseId: String,
+    val overstyrInnsynsregler: String? = null,
+)

--- a/src/main/kotlin/no/nav/syfo/infrastructure/dokarkiv/dto/JournalpostResponse.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/dokarkiv/dto/JournalpostResponse.kt
@@ -1,0 +1,9 @@
+package no.nav.syfo.infrastructure.dokarkiv.dto
+
+data class JournalpostResponse(
+    val dokumenter: List<DokumentInfo>? = null,
+    val journalpostId: Int,
+    val journalpostferdigstilt: Boolean? = null,
+    val journalstatus: String,
+    val melding: String? = null,
+)

--- a/src/main/kotlin/no/nav/syfo/infrastructure/dokarkiv/dto/Sak.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/dokarkiv/dto/Sak.kt
@@ -1,0 +1,11 @@
+package no.nav.syfo.infrastructure.dokarkiv.dto
+
+enum class SaksType(
+    val value: String,
+) {
+    GENERELL("GENERELL_SAK"),
+}
+
+data class Sak(
+    val sakstype: String = SaksType.GENERELL.value,
+)


### PR DESCRIPTION
- Legger til `dokarkiv` klient
- Legger til skjelett for cronjob for å gjøre journalføring av forhåndsvarsler