### PR TITLE
IS-2092: Add endpoint for creating forhandsvarsel

### DIFF
--- a/src/main/kotlin/no/nav/syfo/api/ApiModule.kt
+++ b/src/main/kotlin/no/nav/syfo/api/ApiModule.kt
@@ -19,6 +19,7 @@ import no.nav.syfo.api.auth.JwtIssuerType
 import no.nav.syfo.api.auth.installJwtAuthentication
 import no.nav.syfo.api.endpoints.metricEndpoints
 import no.nav.syfo.api.endpoints.podEndpoints
+import no.nav.syfo.api.endpoints.registerArbeidsuforhetEndpoints
 import no.nav.syfo.infrastructure.database.DatabaseInterface
 import no.nav.syfo.infrastructure.NAV_CALL_ID_HEADER
 import no.nav.syfo.infrastructure.metric.METRICS_REGISTRY
@@ -57,6 +58,9 @@ fun Application.apiModule(
         podEndpoints(applicationState = applicationState, database = database)
         metricEndpoints()
         authenticate(JwtIssuerType.INTERNAL_AZUREAD.name) {
+            registerArbeidsuforhetEndpoints(
+                veilederTilgangskontrollClient = veilederTilgangskontrollClient,
+            )
         }
     }
 }

--- a/src/main/kotlin/no/nav/syfo/api/endpoints/ArbeidsuforhetEndpoints.kt
+++ b/src/main/kotlin/no/nav/syfo/api/endpoints/ArbeidsuforhetEndpoints.kt
@@ -1,0 +1,42 @@
+package no.nav.syfo.api.endpoints
+
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import no.nav.syfo.api.model.ForhandsvarselDTO
+import no.nav.syfo.infrastructure.veiledertilgang.VeilederTilgangskontrollClient
+import no.nav.syfo.infrastructure.veiledertilgang.VeilederTilgangskontrollPlugin
+import no.nav.syfo.util.getCallId
+import no.nav.syfo.util.getNAVIdent
+import no.nav.syfo.util.getPersonIdent
+
+const val arbeidsuforhetApiBasePath = "/api/internad/v1/arbeidsuforhet"
+const val forhandsvarselPath = "/forhandsvarsel"
+
+private const val API_ACTION = "access arbeidsuforhet for person"
+
+fun Route.registerArbeidsuforhetEndpoints(
+    veilederTilgangskontrollClient: VeilederTilgangskontrollClient,
+) {
+    route(arbeidsuforhetApiBasePath) {
+        install(VeilederTilgangskontrollPlugin) {
+            this.action = API_ACTION
+            this.veilederTilgangskontrollClient = veilederTilgangskontrollClient
+        }
+
+        post(forhandsvarselPath) {
+            val requestDTO = call.receive<ForhandsvarselDTO>()
+            if (requestDTO.document.isEmpty()) {
+                throw IllegalArgumentException("Forhandsvarsel can't have an empty document")
+            }
+
+            val personIdent = call.getPersonIdent()
+            val navIdent = call.getNAVIdent()
+            val callId = call.getCallId()
+
+            call.respond(HttpStatusCode.Created)
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/api/model/ForhandsvarselDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/api/model/ForhandsvarselDTO.kt
@@ -1,0 +1,8 @@
+package no.nav.syfo.api.model
+
+import no.nav.syfo.domain.DocumentComponent
+
+data class ForhandsvarselDTO(
+    val begrunnelse: String,
+    val document: List<DocumentComponent> = emptyList()
+)

--- a/src/main/kotlin/no/nav/syfo/domain/DocumentComponent.kt
+++ b/src/main/kotlin/no/nav/syfo/domain/DocumentComponent.kt
@@ -1,0 +1,31 @@
+package no.nav.syfo.domain
+
+data class DocumentComponent(
+    val type: DocumentComponentType,
+    val key: String? = null,
+    val title: String?,
+    val texts: List<String>,
+) {
+    companion object {
+        internal val illegalCharacters = listOf('\u0002')
+    }
+}
+
+fun List<DocumentComponent>.sanitizeForPdfGen(): List<DocumentComponent> = this.map {
+    it.copy(
+        texts = it.texts.map { text ->
+            text.toCharArray()
+                .filter { char -> char !in DocumentComponent.illegalCharacters }
+                .joinToString("")
+        }
+    )
+}
+
+enum class DocumentComponentType {
+    HEADER_H1,
+    HEADER_H2,
+    HEADER_H3,
+    PARAGRAPH,
+    BULLET_POINTS,
+    LINK,
+}

--- a/src/main/kotlin/no/nav/syfo/infrastructure/veiledertilgang/VeilederTilgangskontrollPlugin.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/veiledertilgang/VeilederTilgangskontrollPlugin.kt
@@ -1,0 +1,48 @@
+package no.nav.syfo.infrastructure.veiledertilgang
+
+import io.ktor.server.application.*
+import io.ktor.server.auth.*
+import no.nav.syfo.infrastructure.NAV_PERSONIDENT_HEADER
+import no.nav.syfo.util.getBearerHeader
+import no.nav.syfo.util.getCallId
+import no.nav.syfo.util.getPersonIdent
+
+class VeilederTilgangskontrollPluginConfig {
+    lateinit var action: String
+    lateinit var veilederTilgangskontrollClient: VeilederTilgangskontrollClient
+}
+
+val VeilederTilgangskontrollPlugin = createRouteScopedPlugin(
+    name = "VeilederTilgangskontrollPlugin",
+    createConfiguration = ::VeilederTilgangskontrollPluginConfig
+) {
+    val action = this.pluginConfig.action
+    val veilederTilgangskontrollClient = this.pluginConfig.veilederTilgangskontrollClient
+
+    on(AuthenticationChecked) { call ->
+        when {
+            call.isHandled -> {
+                /** Autentisering kan ha feilet og gitt respons på kallet, ikke gå videre */
+            }
+
+            else -> {
+                val callId = call.getCallId()
+                val personIdent = call.getPersonIdent()
+                    ?: throw IllegalArgumentException("Failed to $action: No $NAV_PERSONIDENT_HEADER supplied in request header")
+                val token = call.getBearerHeader()
+                    ?: throw IllegalArgumentException("Failed to complete the following action: $action. No Authorization header supplied")
+
+                val hasAccess = veilederTilgangskontrollClient.hasAccess(
+                    callId = callId,
+                    personIdent = personIdent,
+                    token = token,
+                )
+                if (!hasAccess) {
+                    throw ForbiddenAccessVeilederException(
+                        action = action,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/syfo/ExternalMockEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/ExternalMockEnvironment.kt
@@ -1,0 +1,31 @@
+package no.nav.syfo
+
+import no.nav.syfo.infrastructure.azuread.AzureAdClient
+import no.nav.syfo.infrastructure.database.TestDatabase
+import no.nav.syfo.infrastructure.mock.mockHttpClient
+import no.nav.syfo.infrastructure.wellknown.WellKnown
+import java.nio.file.Paths
+
+fun wellKnownInternalAzureAD(): WellKnown {
+    val path = "src/test/resources/jwkset.json"
+    val uri = Paths.get(path).toUri().toURL()
+    return WellKnown(
+        issuer = "https://sts.issuer.net/veileder/v2",
+        jwksUri = uri.toString()
+    )
+}
+
+class ExternalMockEnvironment private constructor() {
+    val applicationState: ApplicationState = testAppState()
+    val database = TestDatabase()
+    val environment = testEnvironment()
+    val mockHttpClient = mockHttpClient(environment = environment)
+    val wellKnownInternalAzureAD = wellKnownInternalAzureAD()
+    val azureAdClient = AzureAdClient(
+        azureEnvironment = environment.azure,
+        httpClient = mockHttpClient,
+    )
+    companion object {
+        val instance: ExternalMockEnvironment = ExternalMockEnvironment()
+    }
+}

--- a/src/test/kotlin/no/nav/syfo/TestEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/TestEnvironment.kt
@@ -1,0 +1,42 @@
+package no.nav.syfo
+
+import no.nav.syfo.infrastructure.ClientEnvironment
+import no.nav.syfo.infrastructure.ClientsEnvironment
+import no.nav.syfo.infrastructure.OpenClientEnvironment
+import no.nav.syfo.infrastructure.azuread.AzureEnvironment
+import no.nav.syfo.infrastructure.database.DatabaseEnvironment
+
+fun testEnvironment() = Environment(
+    database = DatabaseEnvironment(
+        host = "localhost",
+        port = "5432",
+        name = "isaktivitetskrav_dev",
+        username = "username",
+        password = "password",
+    ),
+    azure = AzureEnvironment(
+        appClientId = "isarbeidsuforhet-client-id",
+        appClientSecret = "isarbeidsuforhet-secret",
+        appWellKnownUrl = "wellknown",
+        openidConfigTokenEndpoint = "azureOpenIdTokenEndpoint",
+    ),
+    clients = ClientsEnvironment(
+        istilgangskontroll = ClientEnvironment(
+            baseUrl = "isTilgangskontrollUrl",
+            clientId = "dev-gcp.teamsykefravr.istilgangskontroll",
+        ),
+        pdl = ClientEnvironment(
+            baseUrl = "pdlUrl",
+            clientId = "pdlClientId",
+        ),
+        isarbeidsuforhetpdfgen = OpenClientEnvironment(
+            baseUrl = "isarbeidsuforhetpdfgenUrl",
+        ),
+    ),
+    electorPath = "electorPath",
+)
+
+fun testAppState() = ApplicationState(
+    alive = true,
+    ready = true,
+)

--- a/src/test/kotlin/no/nav/syfo/UserConstants.kt
+++ b/src/test/kotlin/no/nav/syfo/UserConstants.kt
@@ -1,0 +1,9 @@
+package no.nav.syfo
+
+import no.nav.syfo.domain.PersonIdent
+
+object UserConstants {
+    val ARBEIDSTAKER_PERSONIDENT = PersonIdent("12345678910")
+    val ARBEIDSTAKER_PERSONIDENT_VEILEDER_NO_ACCESS = PersonIdent("11111111111")
+    const val VEILEDER_IDENT = "Z999999"
+}

--- a/src/test/kotlin/no/nav/syfo/api/JWTUtil.kt
+++ b/src/test/kotlin/no/nav/syfo/api/JWTUtil.kt
@@ -1,0 +1,62 @@
+package no.nav.syfo.api
+
+import com.auth0.jwt.JWT
+import com.auth0.jwt.algorithms.Algorithm
+import com.nimbusds.jose.jwk.JWKSet
+import com.nimbusds.jose.jwk.RSAKey
+import no.nav.syfo.util.JWT_CLAIM_NAVIDENT
+import java.io.IOException
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.text.ParseException
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.util.*
+
+const val keyId = "localhost-signer"
+
+// Mock of JWT-token supplied by AzureAD. KeyId must match kid i jwkset.json
+fun generateJWT(
+    audience: String,
+    issuer: String,
+    navIdent: String? = null,
+    subject: String? = null,
+    expiry: LocalDateTime? = LocalDateTime.now().plusHours(1)
+): String {
+    val now = Date()
+    val key = getDefaultRSAKey()
+    val alg = Algorithm.RSA256(key.toRSAPublicKey(), key.toRSAPrivateKey())
+
+    return JWT.create()
+        .withKeyId(keyId)
+        .withSubject(subject ?: "subject")
+        .withIssuer(issuer)
+        .withAudience(audience)
+        .withJWTId(UUID.randomUUID().toString())
+        .withClaim("ver", "1.0")
+        .withClaim("nonce", "myNonce")
+        .withClaim("auth_time", now)
+        .withClaim("nbf", now)
+        .withClaim("iat", now)
+        .withClaim("exp", Date.from(expiry?.atZone(ZoneId.systemDefault())?.toInstant()))
+        .withClaim(JWT_CLAIM_NAVIDENT, navIdent)
+        .sign(alg)
+}
+
+private fun getDefaultRSAKey(): RSAKey {
+    return getJWKSet().getKeyByKeyId(keyId) as RSAKey
+}
+
+private fun getJWKSet(): JWKSet {
+    val jwkSet = getFileAsString("src/test/resources/jwkset.json")
+    try {
+        return JWKSet.parse(jwkSet)
+    } catch (io: IOException) {
+        throw RuntimeException(io)
+    } catch (io: ParseException) {
+        throw RuntimeException(io)
+    }
+}
+
+fun getFileAsString(filePath: String) = String(Files.readAllBytes(Paths.get(filePath)), StandardCharsets.UTF_8)

--- a/src/test/kotlin/no/nav/syfo/api/TestApiModule.kt
+++ b/src/test/kotlin/no/nav/syfo/api/TestApiModule.kt
@@ -1,0 +1,25 @@
+package no.nav.syfo.api
+
+import io.ktor.server.application.*
+import no.nav.syfo.ExternalMockEnvironment
+import no.nav.syfo.infrastructure.veiledertilgang.VeilederTilgangskontrollClient
+import no.nav.syfo.wellKnownInternalAzureAD
+
+fun Application.testApiModule(
+    externalMockEnvironment: ExternalMockEnvironment,
+) {
+    val database = externalMockEnvironment.database
+    val veilederTilgangskontrollClient = VeilederTilgangskontrollClient(
+        azureAdClient = externalMockEnvironment.azureAdClient,
+        clientEnvironment = externalMockEnvironment.environment.clients.istilgangskontroll,
+        httpClient = externalMockEnvironment.mockHttpClient,
+    )
+
+    this.apiModule(
+        applicationState = externalMockEnvironment.applicationState,
+        environment = externalMockEnvironment.environment,
+        wellKnownInternalAzureAD = wellKnownInternalAzureAD(),
+        veilederTilgangskontrollClient = veilederTilgangskontrollClient,
+        database = database,
+    )
+}

--- a/src/test/kotlin/no/nav/syfo/api/TestApplicationEngineUtils.kt
+++ b/src/test/kotlin/no/nav/syfo/api/TestApplicationEngineUtils.kt
@@ -1,0 +1,66 @@
+package no.nav.syfo.api
+
+import no.nav.syfo.UserConstants
+import io.ktor.http.*
+import io.ktor.server.testing.*
+import no.nav.syfo.infrastructure.NAV_PERSONIDENT_HEADER
+import no.nav.syfo.infrastructure.bearerHeader
+import org.amshove.kluent.shouldBeEqualTo
+
+fun TestApplicationEngine.testMissingToken(url: String, httpMethod: HttpMethod) {
+    with(
+        handleRequest(httpMethod, url) {}
+    ) {
+        response.status() shouldBeEqualTo HttpStatusCode.Unauthorized
+    }
+}
+
+fun TestApplicationEngine.testMissingPersonIdent(
+    url: String,
+    validToken: String,
+    httpMethod: HttpMethod,
+) {
+    with(
+        handleRequest(httpMethod, url) {
+            addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
+        }
+    ) {
+        response.status() shouldBeEqualTo HttpStatusCode.BadRequest
+    }
+}
+
+fun TestApplicationEngine.testInvalidPersonIdent(
+    url: String,
+    validToken: String,
+    httpMethod: HttpMethod,
+) {
+    with(
+        handleRequest(httpMethod, url) {
+            addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
+            addHeader(
+                NAV_PERSONIDENT_HEADER,
+                UserConstants.ARBEIDSTAKER_PERSONIDENT.value.drop(1)
+            )
+        }
+    ) {
+        response.status() shouldBeEqualTo HttpStatusCode.BadRequest
+    }
+}
+
+fun TestApplicationEngine.testDeniedPersonAccess(
+    url: String,
+    validToken: String,
+    httpMethod: HttpMethod,
+) {
+    with(
+        handleRequest(httpMethod, url) {
+            addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
+            addHeader(
+                NAV_PERSONIDENT_HEADER,
+                UserConstants.ARBEIDSTAKER_PERSONIDENT_VEILEDER_NO_ACCESS.value
+            )
+        }
+    ) {
+        response.status() shouldBeEqualTo HttpStatusCode.Forbidden
+    }
+}

--- a/src/test/kotlin/no/nav/syfo/api/endpoints/ArbeidsuforhetEndpointsSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/api/endpoints/ArbeidsuforhetEndpointsSpek.kt
@@ -1,0 +1,92 @@
+package no.nav.syfo.api.endpoints
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.ktor.http.*
+import io.ktor.server.testing.*
+import no.nav.syfo.ExternalMockEnvironment
+import no.nav.syfo.UserConstants
+import no.nav.syfo.api.*
+import no.nav.syfo.api.model.ForhandsvarselDTO
+import no.nav.syfo.generator.generateDocumentComponent
+import no.nav.syfo.infrastructure.NAV_PERSONIDENT_HEADER
+import no.nav.syfo.infrastructure.bearerHeader
+import no.nav.syfo.util.configuredJacksonMapper
+import org.amshove.kluent.shouldBeEqualTo
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+object ArbeidsuforhetEndpointsSpek : Spek({
+
+    val objectMapper: ObjectMapper = configuredJacksonMapper()
+    val urlForhandsvarsel = "$arbeidsuforhetApiBasePath/$forhandsvarselPath"
+
+    describe(ArbeidsuforhetEndpointsSpek::class.java.simpleName) {
+        with(TestApplicationEngine()) {
+            start()
+            val externalMockEnvironment = ExternalMockEnvironment.instance
+
+            application.testApiModule(
+                externalMockEnvironment = externalMockEnvironment,
+            )
+            val validToken = generateJWT(
+                audience = externalMockEnvironment.environment.azure.appClientId,
+                issuer = externalMockEnvironment.wellKnownInternalAzureAD.issuer,
+                navIdent = UserConstants.VEILEDER_IDENT,
+            )
+            val begrunnelse = "Dette er en begrunnelse for forhåndsvarsel 8-4"
+            val forhandsvarselDTO = ForhandsvarselDTO(
+                begrunnelse = begrunnelse,
+                document = generateDocumentComponent(
+                    fritekst = begrunnelse,
+                    header = "Forhåndsvarsel"
+                )
+            )
+            val personIdent = UserConstants.ARBEIDSTAKER_PERSONIDENT.value
+
+            describe("Forhåndsvarsel") {
+                describe("Happy path") {
+                    it("Successfully creates a new forhandsvarsel") {
+                        with(
+                            handleRequest(HttpMethod.Post, urlForhandsvarsel) {
+                                addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                                addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
+                                addHeader(NAV_PERSONIDENT_HEADER, personIdent)
+                                setBody(objectMapper.writeValueAsString(forhandsvarselDTO))
+                            }
+                        ) {
+                            response.status() shouldBeEqualTo HttpStatusCode.Created
+                        }
+                    }
+                }
+
+                describe("Unhappy path") {
+                    it("Fails if document is empty") {
+                        val forhandsvarselWithoutDocument = forhandsvarselDTO.copy(document = emptyList())
+                        with(
+                            handleRequest(HttpMethod.Post, urlForhandsvarsel) {
+                                addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                                addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
+                                addHeader(NAV_PERSONIDENT_HEADER, personIdent)
+                                setBody(objectMapper.writeValueAsString(forhandsvarselWithoutDocument))
+                            }
+                        ) {
+                            response.status() shouldBeEqualTo HttpStatusCode.BadRequest
+                        }
+                    }
+                    it("Returns status Unauthorized if no token is supplied") {
+                        testMissingToken(urlForhandsvarsel, HttpMethod.Post)
+                    }
+                    it("Returns status Forbidden if denied access to person") {
+                        testDeniedPersonAccess(urlForhandsvarsel, validToken, HttpMethod.Post)
+                    }
+                    it("Returns status BadRequest if no $NAV_PERSONIDENT_HEADER is supplied") {
+                        testMissingPersonIdent(urlForhandsvarsel, validToken, HttpMethod.Post)
+                    }
+                    it("Returns status BadRequest if $NAV_PERSONIDENT_HEADER with invalid PersonIdent is supplied") {
+                        testInvalidPersonIdent(urlForhandsvarsel, validToken, HttpMethod.Post)
+                    }
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/no/nav/syfo/generator/DocumentComponentGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/generator/DocumentComponentGenerator.kt
@@ -1,0 +1,23 @@
+package no.nav.syfo.generator
+
+import no.nav.syfo.domain.DocumentComponent
+import no.nav.syfo.domain.DocumentComponentType
+
+fun generateDocumentComponent(fritekst: String, header: String = "Standard header") = listOf(
+    DocumentComponent(
+        type = DocumentComponentType.HEADER_H1,
+        title = null,
+        texts = listOf(header),
+    ),
+    DocumentComponent(
+        type = DocumentComponentType.PARAGRAPH,
+        title = null,
+        texts = listOf(fritekst),
+    ),
+    DocumentComponent(
+        type = DocumentComponentType.PARAGRAPH,
+        key = "Standardtekst",
+        title = null,
+        texts = listOf("Dette er en standardtekst"),
+    ),
+)

--- a/src/test/kotlin/no/nav/syfo/infrastructure/mock/AzureADMock.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/mock/AzureADMock.kt
@@ -1,0 +1,13 @@
+package no.nav.syfo.infrastructure.mock
+
+import io.ktor.client.engine.mock.*
+import io.ktor.client.request.*
+import no.nav.syfo.infrastructure.azuread.AzureAdTokenResponse
+
+fun MockRequestHandleScope.azureAdMockResponse(): HttpResponseData = respond(
+    AzureAdTokenResponse(
+        access_token = "token",
+        expires_in = 3600,
+        token_type = "type",
+    )
+)

--- a/src/test/kotlin/no/nav/syfo/infrastructure/mock/MockHttpClient.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/mock/MockHttpClient.kt
@@ -1,0 +1,22 @@
+package no.nav.syfo.infrastructure.mock
+
+import io.ktor.client.*
+import io.ktor.client.engine.mock.*
+import no.nav.syfo.Environment
+import no.nav.syfo.infrastructure.commonConfig
+
+fun mockHttpClient(environment: Environment) = HttpClient(MockEngine) {
+    commonConfig()
+    engine {
+        addHandler { request ->
+            val requestUrl = request.url.encodedPath
+            when {
+                requestUrl == "/${environment.azure.openidConfigTokenEndpoint}" -> azureAdMockResponse()
+                requestUrl.startsWith("/${environment.clients.istilgangskontroll.baseUrl}") -> tilgangskontrollResponse(
+                    request
+                )
+                else -> error("Unhandled ${request.url.encodedPath}")
+            }
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/syfo/infrastructure/mock/MockUtils.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/mock/MockUtils.kt
@@ -1,0 +1,19 @@
+package no.nav.syfo.infrastructure.mock
+
+import io.ktor.client.engine.mock.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+import no.nav.syfo.util.configuredJacksonMapper
+
+val mapper = configuredJacksonMapper()
+
+fun <T> MockRequestHandleScope.respond(body: T): HttpResponseData =
+    respond(
+        mapper.writeValueAsString(body),
+        HttpStatusCode.OK,
+        headersOf(HttpHeaders.ContentType, "application/json")
+    )
+
+suspend inline fun <reified T> HttpRequestData.receiveBody(): T {
+    return mapper.readValue(body.toByteArray(), T::class.java)
+}

--- a/src/test/kotlin/no/nav/syfo/infrastructure/mock/TilgangskontrollMock.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/mock/TilgangskontrollMock.kt
@@ -1,0 +1,14 @@
+package no.nav.syfo.infrastructure.mock
+
+import io.ktor.client.engine.mock.*
+import io.ktor.client.request.*
+import no.nav.syfo.UserConstants.ARBEIDSTAKER_PERSONIDENT_VEILEDER_NO_ACCESS
+import no.nav.syfo.infrastructure.NAV_PERSONIDENT_HEADER
+import no.nav.syfo.infrastructure.veiledertilgang.Tilgang
+
+fun MockRequestHandleScope.tilgangskontrollResponse(request: HttpRequestData): HttpResponseData {
+    return when (request.headers[NAV_PERSONIDENT_HEADER]) {
+        ARBEIDSTAKER_PERSONIDENT_VEILEDER_NO_ACCESS.value -> respond(Tilgang(erGodkjent = false))
+        else -> respond(Tilgang(erGodkjent = true))
+    }
+}

--- a/src/test/resources/jwkset.json
+++ b/src/test/resources/jwkset.json
@@ -1,0 +1,13 @@
+{
+  "keys": [
+    {
+      "kty": "RSA",
+      "d": "MRf73iiXUEhJFxDTtJ5rEHNQsAG8XFuXkz9vXXbMp1_OTo11bEx3SnHiwmO_mSAAeXWNJniLw07V1-nk551h5in_ueAPwXTOf8qddacvDEBZwcxeqfu_Kjh1R0ji8Xn1a037CpH2IO34Lyw2gmsGFdMZgDwa5Z0KJjPCU6W8tF6CA-2omAdNzrFaWtaPFpBC0NzYaaB111bKIXxngG97Cnu81deEEKmX-vL-O4tpvUUybuquxrlFvVlTeYlrQqv50_IKsKSYkg-iu1cbqIiWrRq9eTmA6EppmZbqHjKSM5JYFbPB_oZ9QeHKnp1_MTom-jKMEpw18qq-PzdX_skZWQ",
+      "e": "AQAB",
+      "use": "sig",
+      "kid": "localhost-signer",
+      "alg": "RS256",
+      "n": "lFTMP9TSUwLua0G8M7foqmdUS2us1-JOF8H_tClVG3IEQMRvMmHJoGSdldWDHsNwRG3Wevl_8fZoGocw9hPqj93j-vI4-ZkbxwhPyRqlS0FNIPD1Ln5R6AmHu7b-paRIz3lvqpyTRwnGBI9weE4u6WOpOQ8DjJMNPq4WcM42AgDJAvc6UuhcWW_MLIsjkKp_VYKxzthSuiRAxXi8Pz4ZhiTAEZI-UN61DYU9YEFNujg5XtIQsRwQn1Vj7BknGwkdf_iCGJgDlKUOz9hAojOMXTAwetUx6I5nngIM5vaXWJCmKn6SzcTYgHWWVrn8qaSazioaydLaYN9NuQ0MdIvsQw"
+    }
+  ]
+}


### PR DESCRIPTION
## Hva har blitt gjort?

Satt opp API for forhåndsvarsel med tilhørende test. Det ble mye som måtte settes opp for å få testene opp og kjøre. Hvis dere vil at jeg skal flytte test-tingene ut i en egen PR så kan jeg også det 👍🏼

#### Trenger innspill på:
- Litt usikker på pakke-navn i `application`-laget, så kom gjerne med innspill på det!
- `ForhandsvarselDTO`, den er foreløpig lik som i `isaktivitetskrav`