### PR TITLE
Flytter ClientsEnvironment og HttpClientCommon til infrastructure

### DIFF
--- a/src/main/kotlin/no/nav/syfo/ApplicationEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/ApplicationEnvironment.kt
@@ -1,6 +1,8 @@
 package no.nav.syfo
 
-import no.nav.syfo.api.*
+import no.nav.syfo.infrastructure.ClientEnvironment
+import no.nav.syfo.infrastructure.ClientsEnvironment
+import no.nav.syfo.infrastructure.OpenClientEnvironment
 import no.nav.syfo.infrastructure.azuread.AzureEnvironment
 import no.nav.syfo.infrastructure.database.DatabaseEnvironment
 

--- a/src/main/kotlin/no/nav/syfo/infrastructure/ClientsEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/ClientsEnvironment.kt
@@ -1,4 +1,4 @@
-package no.nav.syfo.api
+package no.nav.syfo.infrastructure
 
 data class ClientsEnvironment(
     val istilgangskontroll: ClientEnvironment,

--- a/src/main/kotlin/no/nav/syfo/infrastructure/HttpClientCommon.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/HttpClientCommon.kt
@@ -1,4 +1,4 @@
-package no.nav.syfo.api
+package no.nav.syfo.infrastructure
 
 import io.ktor.client.*
 import io.ktor.client.engine.*

--- a/src/main/kotlin/no/nav/syfo/infrastructure/azuread/AzureAdClient.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/azuread/AzureAdClient.kt
@@ -7,7 +7,7 @@ import io.ktor.client.request.*
 import io.ktor.client.request.forms.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
-import no.nav.syfo.api.httpClientProxy
+import no.nav.syfo.infrastructure.httpClientProxy
 import org.slf4j.LoggerFactory
 
 class AzureAdClient(

--- a/src/main/kotlin/no/nav/syfo/infrastructure/dokarkiv/DokarkivClient.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/dokarkiv/DokarkivClient.kt
@@ -8,12 +8,12 @@ import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.micrometer.core.instrument.Counter
 import net.logstash.logback.argument.StructuredArguments
-import no.nav.syfo.api.ClientEnvironment
-import no.nav.syfo.api.httpClientDefault
+import no.nav.syfo.infrastructure.ClientEnvironment
 import no.nav.syfo.infrastructure.azuread.AzureAdClient
 import no.nav.syfo.infrastructure.bearerHeader
 import no.nav.syfo.infrastructure.dokarkiv.dto.JournalpostRequest
 import no.nav.syfo.infrastructure.dokarkiv.dto.JournalpostResponse
+import no.nav.syfo.infrastructure.httpClientDefault
 import no.nav.syfo.infrastructure.metric.METRICS_NS
 import no.nav.syfo.infrastructure.metric.METRICS_REGISTRY
 import org.slf4j.LoggerFactory

--- a/src/main/kotlin/no/nav/syfo/infrastructure/pdfgen/PdfGenClient.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/pdfgen/PdfGenClient.kt
@@ -8,8 +8,8 @@ import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.micrometer.core.instrument.Counter
 import net.logstash.logback.argument.StructuredArguments
-import no.nav.syfo.api.httpClientDefault
 import no.nav.syfo.infrastructure.NAV_CALL_ID_HEADER
+import no.nav.syfo.infrastructure.httpClientDefault
 import no.nav.syfo.infrastructure.metric.METRICS_NS
 import no.nav.syfo.infrastructure.metric.METRICS_REGISTRY
 import org.slf4j.LoggerFactory

--- a/src/main/kotlin/no/nav/syfo/infrastructure/pdl/PdlClient.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/pdl/PdlClient.kt
@@ -6,11 +6,11 @@ import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.micrometer.core.instrument.Counter
-import no.nav.syfo.api.ClientEnvironment
-import no.nav.syfo.api.httpClientDefault
 import no.nav.syfo.domain.PersonIdent
+import no.nav.syfo.infrastructure.ClientEnvironment
 import no.nav.syfo.infrastructure.azuread.AzureAdClient
 import no.nav.syfo.infrastructure.bearerHeader
+import no.nav.syfo.infrastructure.httpClientDefault
 import no.nav.syfo.infrastructure.metric.METRICS_NS
 import no.nav.syfo.infrastructure.metric.METRICS_REGISTRY
 import no.nav.syfo.infrastructure.pdl.dto.*

--- a/src/main/kotlin/no/nav/syfo/infrastructure/veiledertilgang/VeilederTilgangskontrollClient.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/veiledertilgang/VeilederTilgangskontrollClient.kt
@@ -8,8 +8,8 @@ import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.micrometer.core.instrument.Counter
 import net.logstash.logback.argument.StructuredArguments
-import no.nav.syfo.api.ClientEnvironment
-import no.nav.syfo.api.httpClientDefault
+import no.nav.syfo.infrastructure.ClientEnvironment
+import no.nav.syfo.infrastructure.httpClientDefault
 import no.nav.syfo.domain.PersonIdent
 import no.nav.syfo.infrastructure.NAV_CALL_ID_HEADER
 import no.nav.syfo.infrastructure.NAV_PERSONIDENT_HEADER

--- a/src/main/kotlin/no/nav/syfo/infrastructure/wellknown/WellKnownClient.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/wellknown/WellKnownClient.kt
@@ -3,7 +3,7 @@ package no.nav.syfo.infrastructure.wellknown
 import io.ktor.client.call.*
 import io.ktor.client.request.*
 import kotlinx.coroutines.runBlocking
-import no.nav.syfo.api.httpClientProxy
+import no.nav.syfo.infrastructure.httpClientProxy
 
 fun getWellKnown(wellKnownUrl: String): WellKnown =
     runBlocking {


### PR DESCRIPTION
Disse brukes til å kalle tredjepart så virker mer logisk at de ligger der.