### PR TITLE
IS-2105: Add forhandsvarsel service

### DIFF
--- a/src/main/kotlin/no/nav/syfo/application/IVarselPdfService.kt
+++ b/src/main/kotlin/no/nav/syfo/application/IVarselPdfService.kt
@@ -1,0 +1,12 @@
+package no.nav.syfo.application
+
+import no.nav.syfo.domain.DocumentComponent
+import no.nav.syfo.domain.PersonIdent
+
+interface IVarselPdfService {
+    suspend fun createVarselPdf(
+        personident: PersonIdent,
+        document: List<DocumentComponent>,
+        callId: String,
+    ): ByteArray
+}

--- a/src/main/kotlin/no/nav/syfo/application/IVurderingRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/application/IVurderingRepository.kt
@@ -1,15 +1,10 @@
 package no.nav.syfo.application
 
-import no.nav.syfo.domain.DocumentComponent
-import no.nav.syfo.domain.PersonIdent
+import no.nav.syfo.domain.Vurdering
 
 interface IVurderingRepository {
-    // TODO: Replace params with domain object(s)
     fun createForhandsvarsel(
         pdf: ByteArray,
-        document: List<DocumentComponent>,
-        personident: PersonIdent,
-        veilederident: String,
-        begrunnelse: String,
+        vurdering: Vurdering,
     )
 }

--- a/src/main/kotlin/no/nav/syfo/application/service/ForhandsvarselService.kt
+++ b/src/main/kotlin/no/nav/syfo/application/service/ForhandsvarselService.kt
@@ -1,0 +1,39 @@
+package no.nav.syfo.application.service
+
+import no.nav.syfo.application.IVarselPdfService
+import no.nav.syfo.application.IVurderingRepository
+import no.nav.syfo.domain.Vurdering
+import no.nav.syfo.domain.DocumentComponent
+import no.nav.syfo.domain.PersonIdent
+
+class ForhandsvarselService(
+    private val vurderingRepository: IVurderingRepository,
+    private val varselPdfService: IVarselPdfService,
+) {
+    suspend fun createForhandsvarsel(
+        personident: PersonIdent,
+        veilederident: String,
+        begrunnelse: String,
+        document: List<DocumentComponent>,
+        callId: String,
+    ): Vurdering {
+        val pdf = varselPdfService.createVarselPdf(
+            personident = personident,
+            document = document,
+            callId = callId,
+        )
+        val vurdering = Vurdering.createForhandsvarsel(
+            personident = personident,
+            veilederident = veilederident,
+            begrunnelse = begrunnelse,
+            document = document,
+        )
+
+        vurderingRepository.createForhandsvarsel(
+            pdf = pdf,
+            vurdering = vurdering,
+        )
+
+        return vurdering
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/domain/Varsel.kt
+++ b/src/main/kotlin/no/nav/syfo/domain/Varsel.kt
@@ -1,0 +1,21 @@
+package no.nav.syfo.domain
+
+import no.nav.syfo.util.nowUTC
+import java.time.OffsetDateTime
+import java.util.*
+
+data class Varsel private constructor(
+    val uuid: UUID,
+    val document: List<DocumentComponent>,
+    val createdAt: OffsetDateTime,
+    val journalpostId: String?,
+) {
+    companion object {
+        fun create(document: List<DocumentComponent>) = Varsel(
+            uuid = UUID.randomUUID(),
+            document = document,
+            createdAt = nowUTC(),
+            journalpostId = null,
+        )
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/domain/Vurdering.kt
+++ b/src/main/kotlin/no/nav/syfo/domain/Vurdering.kt
@@ -1,0 +1,37 @@
+package no.nav.syfo.domain
+
+import no.nav.syfo.util.nowUTC
+import java.time.OffsetDateTime
+import java.util.*
+
+data class Vurdering private constructor(
+    val uuid: UUID,
+    val personident: PersonIdent,
+    val createdAt: OffsetDateTime,
+    val veilederident: String,
+    val type: VurderingType,
+    val begrunnelse: String,
+    val varsel: Varsel?,
+) {
+
+    companion object {
+        fun createForhandsvarsel(
+            personident: PersonIdent,
+            veilederident: String,
+            begrunnelse: String,
+            document: List<DocumentComponent>,
+        ) = Vurdering(
+            uuid = UUID.randomUUID(),
+            personident = personident,
+            createdAt = nowUTC(),
+            veilederident = veilederident,
+            type = VurderingType.FORHANDSVARSEL,
+            begrunnelse = begrunnelse,
+            varsel = Varsel.create(document),
+        )
+    }
+}
+
+enum class VurderingType {
+    FORHANDSVARSEL, OPPFYLT, STANS
+}

--- a/src/main/kotlin/no/nav/syfo/infrastructure/pdfgen/PdfGenClient.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/pdfgen/PdfGenClient.kt
@@ -21,11 +21,11 @@ class PdfGenClient(
 
     suspend fun createForhandsvarselPdf(
         callId: String,
-        payloadString: String, // TODO: Bytt ut med riktig objekt
+        forhandsvarselPdfDTO: VarselPdfDTO,
     ): ByteArray =
         getPdf(
             callId = callId,
-            payload = payloadString,
+            payload = forhandsvarselPdfDTO,
             pdfUrl = "$pdfGenBaseUrl$API_BASE_PATH$FORHANDSVARSEL_PATH"
         ) ?: throw RuntimeException("Failed to request pdf for forhandsvarsel, callId: $callId")
 

--- a/src/main/kotlin/no/nav/syfo/infrastructure/pdfgen/VarselPdfDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/pdfgen/VarselPdfDTO.kt
@@ -1,0 +1,31 @@
+package no.nav.syfo.infrastructure.pdfgen
+
+import no.nav.syfo.domain.DocumentComponent
+import no.nav.syfo.domain.PersonIdent
+import no.nav.syfo.domain.sanitizeForPdfGen
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.util.*
+
+data class VarselPdfDTO private constructor(
+    val mottakerNavn: String,
+    val mottakerFodselsnummer: String,
+    val datoSendt: String,
+    val documentComponents: List<DocumentComponent>,
+) {
+    companion object {
+        private val formatter = DateTimeFormatter.ofPattern("dd. MMMM yyyy", Locale("no", "NO"))
+
+        fun create(
+            mottakerNavn: String,
+            mottakerPersonident: PersonIdent,
+            documentComponents: List<DocumentComponent>,
+        ): VarselPdfDTO =
+            VarselPdfDTO(
+                mottakerNavn = mottakerNavn,
+                mottakerFodselsnummer = mottakerPersonident.value,
+                datoSendt = LocalDate.now().format(formatter),
+                documentComponents = documentComponents.sanitizeForPdfGen()
+            )
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/infrastructure/pdfgen/VarselPdfService.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/pdfgen/VarselPdfService.kt
@@ -1,0 +1,30 @@
+package no.nav.syfo.infrastructure.pdfgen
+
+import no.nav.syfo.application.IVarselPdfService
+import no.nav.syfo.domain.DocumentComponent
+import no.nav.syfo.domain.PersonIdent
+import no.nav.syfo.infrastructure.pdl.PdlClient
+
+class VarselPdfService(
+    private val pdfGenClient: PdfGenClient,
+    private val pdlClient: PdlClient,
+) : IVarselPdfService {
+
+    override suspend fun createVarselPdf(
+        personident: PersonIdent,
+        document: List<DocumentComponent>,
+        callId: String,
+    ): ByteArray {
+        val personNavn = pdlClient.getPerson(personident).fullName
+        val varselPdfDTO = VarselPdfDTO.create(
+            documentComponents = document,
+            mottakerNavn = personNavn,
+            mottakerPersonident = personident,
+        )
+
+        return pdfGenClient.createForhandsvarselPdf(
+            callId = callId,
+            forhandsvarselPdfDTO = varselPdfDTO,
+        )
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/infrastructure/pdl/PdlClient.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/pdl/PdlClient.kt
@@ -21,7 +21,7 @@ class PdlClient(
     private val pdlEnvironment: ClientEnvironment,
 ) {
 
-    private suspend fun getPerson(personIdent: PersonIdent): PdlPerson {
+    suspend fun getPerson(personIdent: PersonIdent): PdlPerson {
         val token = azureAdClient.getSystemToken(pdlEnvironment.clientId)
             ?: throw RuntimeException("Failed to send request to PDL: No token was found")
         val request = PdlHentPersonRequest(getPdlQuery(), PdlHentPersonRequestVariables(personIdent.value))

--- a/src/main/kotlin/no/nav/syfo/infrastructure/pdl/dto/PdlPersonResponse.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/pdl/dto/PdlPersonResponse.kt
@@ -14,7 +14,8 @@ data class PdlHentPerson(
 data class PdlPerson(
     val navn: List<PdlPersonNavn>,
 ) {
-    val fullName: String? = navn.firstOrNull()?.fullName()
+    val fullName: String = navn.firstOrNull()?.fullName()
+        ?: throw RuntimeException("PDL returned empty navn for given fnr")
 }
 
 data class PdlPersonNavn(

--- a/src/main/kotlin/no/nav/syfo/util/DateUtil.kt
+++ b/src/main/kotlin/no/nav/syfo/util/DateUtil.kt
@@ -1,0 +1,7 @@
+package no.nav.syfo.util
+
+import java.time.*
+
+val defaultZoneOffset: ZoneOffset = ZoneOffset.UTC
+
+fun nowUTC(): OffsetDateTime = OffsetDateTime.now(defaultZoneOffset)

--- a/src/test/kotlin/no/nav/syfo/application/service/ForhandsvarselServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/application/service/ForhandsvarselServiceSpek.kt
@@ -1,0 +1,127 @@
+package no.nav.syfo.application.service
+
+import io.mockk.*
+import kotlinx.coroutines.runBlocking
+import no.nav.syfo.UserConstants.ARBEIDSTAKER_PERSONIDENT
+import no.nav.syfo.UserConstants.PDF_FORHANDSVARSEL
+import no.nav.syfo.UserConstants.VEILEDER_IDENT
+import no.nav.syfo.application.IVarselPdfService
+import no.nav.syfo.application.IVurderingRepository
+import no.nav.syfo.generator.generateDocumentComponent
+import org.amshove.kluent.internal.assertFailsWith
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldNotBeEqualTo
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.lang.RuntimeException
+
+object ForhandsvarselServiceSpek : Spek({
+
+    describe(ForhandsvarselServiceSpek::class.java.simpleName) {
+        val vurderingRepositoryMock = mockk<IVurderingRepository>(relaxed = true)
+        val varselPdfServiceMock = mockk<IVarselPdfService>(relaxed = true)
+        val forhandsvarselService = ForhandsvarselService(
+            vurderingRepository = vurderingRepositoryMock,
+            varselPdfService = varselPdfServiceMock,
+        )
+
+        beforeEachTest {
+            clearAllMocks()
+            coEvery {
+                vurderingRepositoryMock.createForhandsvarsel(any(), any())
+            } returns Unit
+            coEvery {
+                varselPdfServiceMock.createVarselPdf(any(), any(), any())
+            } returns PDF_FORHANDSVARSEL
+        }
+
+        describe("Forhåndsvarsel") {
+            val begrunnelse = "En begrunnelse"
+            val document = generateDocumentComponent(begrunnelse)
+            describe("Happy path") {
+                it("Creates forhåndsvarsel") {
+                    runBlocking {
+                        val vurdering = forhandsvarselService.createForhandsvarsel(
+                            personident = ARBEIDSTAKER_PERSONIDENT,
+                            veilederident = VEILEDER_IDENT,
+                            begrunnelse = begrunnelse,
+                            document = document,
+                            callId = "",
+                        )
+
+                        vurdering.varsel shouldNotBeEqualTo null
+                        vurdering.begrunnelse shouldBeEqualTo begrunnelse
+                        vurdering.personident shouldBeEqualTo ARBEIDSTAKER_PERSONIDENT
+                        vurdering.veilederident shouldBeEqualTo VEILEDER_IDENT
+
+                        coVerify(exactly = 1) {
+                            varselPdfServiceMock.createVarselPdf(
+                                personident = ARBEIDSTAKER_PERSONIDENT,
+                                document = document,
+                                callId = "",
+                            )
+                        }
+                        coVerify(exactly = 1) {
+                            vurderingRepositoryMock.createForhandsvarsel(
+                                pdf = PDF_FORHANDSVARSEL,
+                                vurdering = any(),
+                            )
+                        }
+                    }
+                }
+            }
+
+            describe("Unhappy path") {
+                it("Fails when repository fails") {
+                    coEvery {
+                        vurderingRepositoryMock.createForhandsvarsel(any(), any())
+                    } throws Exception("Error in database")
+
+                    runBlocking {
+                        assertFailsWith(Exception::class) {
+                            forhandsvarselService.createForhandsvarsel(
+                                personident = ARBEIDSTAKER_PERSONIDENT,
+                                veilederident = VEILEDER_IDENT,
+                                begrunnelse = begrunnelse,
+                                document = document,
+                                callId = "",
+                            )
+                        }
+
+                        coVerify(exactly = 1) {
+                            varselPdfServiceMock.createVarselPdf(any(), any(), any())
+                        }
+                        coVerify(exactly = 1) {
+                            vurderingRepositoryMock.createForhandsvarsel(any(), any())
+                        }
+                    }
+                }
+
+                it("Fails when pdfGen fails") {
+                    coEvery {
+                        varselPdfServiceMock.createVarselPdf(any(), any(), any())
+                    } throws RuntimeException("Could not create pdf")
+
+                    runBlocking {
+                        assertFailsWith(RuntimeException::class) {
+                            forhandsvarselService.createForhandsvarsel(
+                                personident = ARBEIDSTAKER_PERSONIDENT,
+                                veilederident = VEILEDER_IDENT,
+                                begrunnelse = begrunnelse,
+                                document = document,
+                                callId = "",
+                            )
+                        }
+
+                        coVerify(exactly = 1) {
+                            varselPdfServiceMock.createVarselPdf(any(), any(), any())
+                        }
+                        coVerify(exactly = 0) {
+                            vurderingRepositoryMock.createForhandsvarsel(any(), any())
+                        }
+                    }
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/no/nav/syfo/generator/VarselGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/generator/VarselGenerator.kt
@@ -1,0 +1,10 @@
+package no.nav.syfo.generator
+
+import no.nav.syfo.domain.Varsel
+import no.nav.syfo.domain.DocumentComponent
+
+fun generateVarsel(
+    document: List<DocumentComponent> = generateDocumentComponent(
+        fritekst = "En fritekst",
+    )
+) = Varsel.create(document)

--- a/src/test/kotlin/no/nav/syfo/generator/VurderingGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/generator/VurderingGenerator.kt
@@ -1,0 +1,15 @@
+package no.nav.syfo.generator
+
+import no.nav.syfo.UserConstants
+import no.nav.syfo.domain.*
+
+fun generateForhandsvarselVurdering(
+    personident: PersonIdent = UserConstants.ARBEIDSTAKER_PERSONIDENT,
+    begrunnelse: String = "En begrunnelse",
+    document: List<DocumentComponent> = generateDocumentComponent(begrunnelse),
+) = Vurdering.createForhandsvarsel(
+    personident = personident,
+    veilederident = UserConstants.VEILEDER_IDENT,
+    begrunnelse = begrunnelse,
+    document = document,
+)

--- a/src/test/kotlin/no/nav/syfo/infrastructure/database/VurderingRepositorySpek.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/database/VurderingRepositorySpek.kt
@@ -1,9 +1,11 @@
 package no.nav.syfo.infrastructure.database
 
 import no.nav.syfo.UserConstants
-import no.nav.syfo.generator.generateDocumentComponent
+import no.nav.syfo.generator.generateForhandsvarselVurdering
+import org.amshove.kluent.internal.assertFailsWith
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
+import java.lang.IllegalStateException
 
 class VurderingRepositorySpek : Spek({
     describe(VurderingRepository::class.java.simpleName) {
@@ -16,16 +18,25 @@ class VurderingRepositorySpek : Spek({
         }
 
         describe("createForhandsvarsel") {
+            val vurdering = generateForhandsvarselVurdering()
+
             it("creates vurdering, varsel and pdf in database") {
-                val begrunnelse = "Fin begrunnelse"
                 vurderingRepository.createForhandsvarsel(
                     pdf = UserConstants.PDF_FORHANDSVARSEL,
-                    document = generateDocumentComponent(fritekst = begrunnelse),
-                    personident = UserConstants.ARBEIDSTAKER_PERSONIDENT,
-                    veilederident = UserConstants.VEILEDER_IDENT,
-                    begrunnelse = begrunnelse,
+                    vurdering = vurdering,
                 )
                 // TODO: Sjekk at ting er lagret når vi har implementert spørringer
+            }
+
+            it("fails if vurdering is missing a varsel") {
+                val vurderingWithoutVarsel = generateForhandsvarselVurdering().copy(varsel = null)
+
+                assertFailsWith(IllegalStateException::class) {
+                    vurderingRepository.createForhandsvarsel(
+                        pdf = UserConstants.PDF_FORHANDSVARSEL,
+                        vurdering = vurderingWithoutVarsel,
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
Legger til service for å lagre forhåndsvarsel, og for å generere pdf.

Har ikke tatt i bruk i APIet enda, det blir en annen PR for å gjøre hver PR litt mindre 👍🏼

Tanker om test-oppsett? Jeg har mocket ut en del ting her, ønsker vi å gjøre det sånn for å teste servicen isolert, eller ønsker vi å teste mer integrasjoner? Hvis vi gjør det like isolert som her, så burde vi kanskje ha en egen test for pdf-gen også, når jeg tenker meg om 🤔