### PR TITLE
IS-2105: Update mocks for pdl and pdfgen

### DIFF
--- a/src/main/kotlin/no/nav/syfo/infrastructure/pdl/PdlClient.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/pdl/PdlClient.kt
@@ -19,6 +19,7 @@ import org.slf4j.LoggerFactory
 class PdlClient(
     private val azureAdClient: AzureAdClient,
     private val pdlEnvironment: ClientEnvironment,
+    private val httpClient: HttpClient = httpClientDefault(),
 ) {
 
     suspend fun getPerson(personIdent: PersonIdent): PdlPerson {
@@ -64,7 +65,6 @@ class PdlClient(
             .replace("[\n\r]", "")
 
     companion object {
-        private val httpClient: HttpClient = httpClientDefault()
         private const val PDL_QUERY_PATH = "/pdl/hentPerson.graphql"
 
         // Se behandlingskatalog https://behandlingskatalog.intern.nav.no/

--- a/src/test/kotlin/no/nav/syfo/ExternalMockEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/ExternalMockEnvironment.kt
@@ -3,6 +3,8 @@ package no.nav.syfo
 import no.nav.syfo.infrastructure.azuread.AzureAdClient
 import no.nav.syfo.infrastructure.database.TestDatabase
 import no.nav.syfo.infrastructure.mock.mockHttpClient
+import no.nav.syfo.infrastructure.pdfgen.PdfGenClient
+import no.nav.syfo.infrastructure.pdl.PdlClient
 import no.nav.syfo.infrastructure.wellknown.WellKnown
 import java.nio.file.Paths
 
@@ -23,6 +25,15 @@ class ExternalMockEnvironment private constructor() {
     val wellKnownInternalAzureAD = wellKnownInternalAzureAD()
     val azureAdClient = AzureAdClient(
         azureEnvironment = environment.azure,
+        httpClient = mockHttpClient,
+    )
+    val pdfgenClient = PdfGenClient(
+        pdfGenBaseUrl = environment.clients.isarbeidsuforhetpdfgen.baseUrl,
+        httpClient = mockHttpClient,
+    )
+    val pdlClient = PdlClient(
+        azureAdClient = azureAdClient,
+        pdlEnvironment = environment.clients.pdl,
         httpClient = mockHttpClient,
     )
     companion object {

--- a/src/test/kotlin/no/nav/syfo/UserConstants.kt
+++ b/src/test/kotlin/no/nav/syfo/UserConstants.kt
@@ -5,6 +5,16 @@ import no.nav.syfo.domain.PersonIdent
 object UserConstants {
     val ARBEIDSTAKER_PERSONIDENT = PersonIdent("12345678910")
     val ARBEIDSTAKER_PERSONIDENT_VEILEDER_NO_ACCESS = PersonIdent("11111111111")
+    val ARBEIDSTAKER_PERSONIDENT_NAME_WITH_DASH = PersonIdent("11111111234")
+    val ARBEIDSTAKER_PERSONIDENT_NO_NAME = PersonIdent("11111111222")
+    val ARBEIDSTAKER_PERSONIDENT_PDL_FAILS = PersonIdent("11111111666")
+
     val PDF_FORHANDSVARSEL = byteArrayOf(0x2E, 0x28)
     const val VEILEDER_IDENT = "Z999999"
+
+    const val PERSON_FORNAVN = "Fornavn"
+    const val PERSON_MELLOMNAVN = "Mellomnavn"
+    const val PERSON_ETTERNAVN = "Etternavnesen"
+    const val PERSON_FORNAVN_DASH = "For-Navn"
+    const val PERSON_FULLNAME_DASH = "For-Navn Mellomnavn Etternavnesen"
 }

--- a/src/test/kotlin/no/nav/syfo/api/TestApiModule.kt
+++ b/src/test/kotlin/no/nav/syfo/api/TestApiModule.kt
@@ -3,7 +3,6 @@ package no.nav.syfo.api
 import io.ktor.server.application.*
 import no.nav.syfo.ExternalMockEnvironment
 import no.nav.syfo.infrastructure.veiledertilgang.VeilederTilgangskontrollClient
-import no.nav.syfo.wellKnownInternalAzureAD
 
 fun Application.testApiModule(
     externalMockEnvironment: ExternalMockEnvironment,
@@ -18,7 +17,7 @@ fun Application.testApiModule(
     this.apiModule(
         applicationState = externalMockEnvironment.applicationState,
         environment = externalMockEnvironment.environment,
-        wellKnownInternalAzureAD = wellKnownInternalAzureAD(),
+        wellKnownInternalAzureAD = externalMockEnvironment.wellKnownInternalAzureAD,
         veilederTilgangskontrollClient = veilederTilgangskontrollClient,
         database = database,
     )

--- a/src/test/kotlin/no/nav/syfo/generator/PdlGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/generator/PdlGenerator.kt
@@ -1,0 +1,35 @@
+package no.nav.syfo.generator
+
+import no.nav.syfo.UserConstants
+import no.nav.syfo.infrastructure.pdl.dto.*
+
+fun generatePdlPersonResponse(pdlPersonNavn: PdlPersonNavn? = null, errors: List<PdlError>? = null) = PdlPersonResponse(
+    errors = errors,
+    data = generatePdlHentPerson(pdlPersonNavn)
+)
+
+fun generatePdlPersonNavn(): PdlPersonNavn = PdlPersonNavn(
+    fornavn = UserConstants.PERSON_FORNAVN,
+    mellomnavn = UserConstants.PERSON_MELLOMNAVN,
+    etternavn = UserConstants.PERSON_ETTERNAVN,
+)
+
+fun generatePdlHentPerson(
+    pdlPersonNavn: PdlPersonNavn?,
+): PdlHentPerson = PdlHentPerson(
+    hentPerson = PdlPerson(
+        navn = if (pdlPersonNavn != null) listOf(pdlPersonNavn) else emptyList(),
+    )
+)
+
+fun generatePdlError() = listOf(
+    PdlError(
+        message = "Error in PDL",
+        locations = emptyList(),
+        path = null,
+        extensions = PdlErrorExtension(
+            code = null,
+            classification = "",
+        )
+    )
+)

--- a/src/test/kotlin/no/nav/syfo/infrastructure/mock/MockHttpClient.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/mock/MockHttpClient.kt
@@ -15,6 +15,10 @@ fun mockHttpClient(environment: Environment) = HttpClient(MockEngine) {
                 requestUrl.startsWith("/${environment.clients.istilgangskontroll.baseUrl}") -> tilgangskontrollResponse(
                     request
                 )
+                requestUrl.startsWith("/${environment.clients.isarbeidsuforhetpdfgen.baseUrl}") -> pdfGenClientMockResponse(
+                    request
+                )
+                requestUrl.startsWith("/${environment.clients.pdl.baseUrl}") -> pdlMockResponse(request)
                 else -> error("Unhandled ${request.url.encodedPath}")
             }
         }

--- a/src/test/kotlin/no/nav/syfo/infrastructure/mock/PdfGenClientMock.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/mock/PdfGenClientMock.kt
@@ -1,0 +1,17 @@
+package no.nav.syfo.infrastructure.mock
+
+import io.ktor.client.engine.mock.*
+import io.ktor.client.request.*
+import no.nav.syfo.UserConstants
+import no.nav.syfo.infrastructure.pdfgen.PdfGenClient
+
+fun MockRequestHandleScope.pdfGenClientMockResponse(request: HttpRequestData): HttpResponseData {
+    val requestUrl = request.url.encodedPath
+
+    return when {
+        requestUrl.endsWith(PdfGenClient.Companion.FORHANDSVARSEL_PATH) -> {
+            respond(content = UserConstants.PDF_FORHANDSVARSEL)
+        }
+        else -> error("Unhandled pdf ${request.url.encodedPath}")
+    }
+}

--- a/src/test/kotlin/no/nav/syfo/infrastructure/mock/PdlMock.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/mock/PdlMock.kt
@@ -1,0 +1,29 @@
+package no.nav.syfo.infrastructure.mock
+
+import io.ktor.client.engine.mock.*
+import io.ktor.client.request.*
+import no.nav.syfo.UserConstants
+import no.nav.syfo.domain.PersonIdent
+import no.nav.syfo.generator.generatePdlError
+import no.nav.syfo.generator.generatePdlPersonNavn
+import no.nav.syfo.generator.generatePdlPersonResponse
+import no.nav.syfo.infrastructure.pdl.dto.PdlHentPersonRequest
+import no.nav.syfo.infrastructure.pdl.dto.PdlPersonNavn
+
+suspend fun MockRequestHandleScope.pdlMockResponse(request: HttpRequestData): HttpResponseData {
+    val pdlRequest = request.receiveBody<PdlHentPersonRequest>()
+    return when (PersonIdent(pdlRequest.variables.ident)) {
+        UserConstants.ARBEIDSTAKER_PERSONIDENT_NO_NAME -> respond(generatePdlPersonResponse(pdlPersonNavn = null))
+        UserConstants.ARBEIDSTAKER_PERSONIDENT_NAME_WITH_DASH -> respond(
+            generatePdlPersonResponse(
+                PdlPersonNavn(
+                    fornavn = UserConstants.PERSON_FORNAVN_DASH,
+                    mellomnavn = UserConstants.PERSON_MELLOMNAVN,
+                    etternavn = UserConstants.PERSON_ETTERNAVN,
+                )
+            )
+        )
+        UserConstants.ARBEIDSTAKER_PERSONIDENT_PDL_FAILS -> respond(generatePdlPersonResponse(errors = generatePdlError()))
+        else -> respond(generatePdlPersonResponse(generatePdlPersonNavn()))
+    }
+}

--- a/src/test/kotlin/no/nav/syfo/infrastructure/pdl/PdlClientSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/pdl/PdlClientSpek.kt
@@ -1,0 +1,97 @@
+package no.nav.syfo.infrastructure.pdl
+
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import no.nav.syfo.ExternalMockEnvironment
+import no.nav.syfo.UserConstants
+import no.nav.syfo.infrastructure.azuread.AzureAdClient
+import no.nav.syfo.infrastructure.pdl.dto.PdlPerson
+import no.nav.syfo.infrastructure.pdl.dto.PdlPersonNavn
+import org.amshove.kluent.internal.assertFailsWith
+import org.amshove.kluent.shouldBeEqualTo
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+object PdlClientSpek : Spek({
+    val externalMockEnvironment = ExternalMockEnvironment.instance
+    val pdlClient = PdlClient(
+        azureAdClient = externalMockEnvironment.azureAdClient,
+        pdlEnvironment = externalMockEnvironment.environment.clients.pdl,
+        httpClient = externalMockEnvironment.mockHttpClient,
+    )
+
+    describe(PdlClient::class.java.simpleName) {
+        describe("Happy case") {
+            it("returns person from pdl") {
+                runBlocking {
+                    val person = pdlClient.getPerson(UserConstants.ARBEIDSTAKER_PERSONIDENT)
+                    person.navn.size shouldBeEqualTo 1
+                    person.navn[0].fornavn shouldBeEqualTo UserConstants.PERSON_FORNAVN
+                }
+            }
+
+            it("returns fullname from person") {
+                val pdlPerson = PdlPerson(
+                    navn = listOf(
+                        PdlPersonNavn(
+                            fornavn = UserConstants.PERSON_FORNAVN,
+                            mellomnavn = UserConstants.PERSON_MELLOMNAVN,
+                            etternavn = UserConstants.PERSON_ETTERNAVN,
+                        )
+                    )
+                )
+                runBlocking {
+                    val person = pdlClient.getPerson(UserConstants.ARBEIDSTAKER_PERSONIDENT)
+                    person.fullName shouldBeEqualTo pdlPerson.fullName
+                }
+            }
+
+            it("returns full name when person has name with dashes") {
+                runBlocking {
+                    val fullname = pdlClient.getPerson(UserConstants.ARBEIDSTAKER_PERSONIDENT_NAME_WITH_DASH).fullName
+                    fullname shouldBeEqualTo UserConstants.PERSON_FULLNAME_DASH
+                }
+            }
+        }
+
+        describe("Unhappy case") {
+            afterEachTest {
+                clearAllMocks()
+            }
+
+            it("throws exception when person is missing name") {
+                runBlocking {
+                    assertFailsWith(RuntimeException::class) {
+                        pdlClient.getPerson(UserConstants.ARBEIDSTAKER_PERSONIDENT_NO_NAME)
+                    }
+                }
+            }
+
+            it("throws exception when pdl has error") {
+                runBlocking {
+                    assertFailsWith(RuntimeException::class) {
+                        pdlClient.getPerson(UserConstants.ARBEIDSTAKER_PERSONIDENT_PDL_FAILS)
+                    }
+                }
+            }
+
+            it("throws exception when AzureAdClient has error") {
+                val azureAdMock = mockk<AzureAdClient>(relaxed = true)
+                val pdlClientMockedAzure = PdlClient(
+                    azureAdClient = azureAdMock,
+                    pdlEnvironment = externalMockEnvironment.environment.clients.pdl,
+                )
+
+                coEvery { azureAdMock.getSystemToken(any()) } returns null
+
+                runBlocking {
+                    assertFailsWith(RuntimeException::class) {
+                        pdlClientMockedAzure.getPerson(UserConstants.ARBEIDSTAKER_PERSONIDENT)
+                    }
+                }
+            }
+        }
+    }
+})


### PR DESCRIPTION
Se https://github.com/navikt/isarbeidsuforhet/pull/20 først.
For å få testet APIet gjennom hele løypa måtte vi ha på plass mocker for pdl og pdfgen.
La også inn en test for `pdlClient`.