### PR TITLE
Move P-classes and repositories to own package

### DIFF
--- a/src/main/kotlin/no/nav/syfo/App.kt
+++ b/src/main/kotlin/no/nav/syfo/App.kt
@@ -9,7 +9,7 @@ import no.nav.syfo.api.apiModule
 import no.nav.syfo.application.IVurderingRepository
 import no.nav.syfo.application.service.ForhandsvarselService
 import no.nav.syfo.infrastructure.azuread.AzureAdClient
-import no.nav.syfo.infrastructure.database.VurderingRepository
+import no.nav.syfo.infrastructure.database.repository.VurderingRepository
 import no.nav.syfo.infrastructure.pdl.PdlClient
 import no.nav.syfo.infrastructure.database.applicationDatabase
 import no.nav.syfo.infrastructure.database.databaseModule

--- a/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/PVarsel.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/PVarsel.kt
@@ -1,4 +1,4 @@
-package no.nav.syfo.infrastructure.database
+package no.nav.syfo.infrastructure.database.repository
 
 import no.nav.syfo.domain.DocumentComponent
 import no.nav.syfo.domain.Varsel

--- a/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/PVarselPdf.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/PVarselPdf.kt
@@ -1,4 +1,4 @@
-package no.nav.syfo.infrastructure.database
+package no.nav.syfo.infrastructure.database.repository
 
 import java.time.OffsetDateTime
 import java.util.UUID

--- a/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/PVurdering.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/PVurdering.kt
@@ -1,4 +1,4 @@
-package no.nav.syfo.infrastructure.database
+package no.nav.syfo.infrastructure.database.repository
 
 import no.nav.syfo.domain.PersonIdent
 import java.time.OffsetDateTime

--- a/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/VarselRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/VarselRepository.kt
@@ -1,10 +1,12 @@
-package no.nav.syfo.infrastructure.database
+package no.nav.syfo.infrastructure.database.repository
 
 import com.fasterxml.jackson.core.type.TypeReference
 import no.nav.syfo.application.IVarselRepository
 import no.nav.syfo.domain.DocumentComponent
 import no.nav.syfo.domain.PersonIdent
 import no.nav.syfo.domain.Varsel
+import no.nav.syfo.infrastructure.database.DatabaseInterface
+import no.nav.syfo.infrastructure.database.toList
 import no.nav.syfo.util.configuredJacksonMapper
 import no.nav.syfo.util.nowUTC
 import java.sql.ResultSet

--- a/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/VurderingRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/VurderingRepository.kt
@@ -1,9 +1,11 @@
-package no.nav.syfo.infrastructure.database
+package no.nav.syfo.infrastructure.database.repository
 
 import no.nav.syfo.application.IVurderingRepository
 import no.nav.syfo.domain.PersonIdent
 import no.nav.syfo.domain.Varsel
 import no.nav.syfo.domain.Vurdering
+import no.nav.syfo.infrastructure.database.DatabaseInterface
+import no.nav.syfo.infrastructure.database.toList
 import no.nav.syfo.util.configuredJacksonMapper
 import java.sql.Connection
 import java.sql.ResultSet

--- a/src/test/kotlin/no/nav/syfo/api/TestApiModule.kt
+++ b/src/test/kotlin/no/nav/syfo/api/TestApiModule.kt
@@ -3,7 +3,7 @@ package no.nav.syfo.api
 import io.ktor.server.application.*
 import no.nav.syfo.ExternalMockEnvironment
 import no.nav.syfo.application.service.ForhandsvarselService
-import no.nav.syfo.infrastructure.database.VurderingRepository
+import no.nav.syfo.infrastructure.database.repository.VurderingRepository
 import no.nav.syfo.infrastructure.pdfgen.VarselPdfService
 import no.nav.syfo.infrastructure.veiledertilgang.VeilederTilgangskontrollClient
 

--- a/src/test/kotlin/no/nav/syfo/application/service/VarselServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/application/service/VarselServiceSpek.kt
@@ -5,8 +5,8 @@ import no.nav.syfo.ExternalMockEnvironment
 import no.nav.syfo.UserConstants
 import no.nav.syfo.domain.Varsel
 import no.nav.syfo.generator.generateForhandsvarselVurdering
-import no.nav.syfo.infrastructure.database.VarselRepository
-import no.nav.syfo.infrastructure.database.VurderingRepository
+import no.nav.syfo.infrastructure.database.repository.VarselRepository
+import no.nav.syfo.infrastructure.database.repository.VurderingRepository
 import no.nav.syfo.infrastructure.database.dropData
 import no.nav.syfo.infrastructure.kafka.esyfovarsel.ArbeidstakervarselProducer
 import org.amshove.kluent.shouldBeEmpty

--- a/src/test/kotlin/no/nav/syfo/infrastructure/database/TestDatabase.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/database/TestDatabase.kt
@@ -1,6 +1,8 @@
 package no.nav.syfo.infrastructure.database
 
 import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import no.nav.syfo.infrastructure.database.repository.*
+import no.nav.syfo.infrastructure.database.repository.toPVarsel
 import org.flywaydb.core.Flyway
 import java.sql.Connection
 import java.util.*

--- a/src/test/kotlin/no/nav/syfo/infrastructure/database/VurderingRepositorySpek.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/database/VurderingRepositorySpek.kt
@@ -3,6 +3,7 @@ package no.nav.syfo.infrastructure.database
 import no.nav.syfo.ExternalMockEnvironment
 import no.nav.syfo.UserConstants
 import no.nav.syfo.generator.generateForhandsvarselVurdering
+import no.nav.syfo.infrastructure.database.repository.VurderingRepository
 import org.amshove.kluent.internal.assertFailsWith
 import org.amshove.kluent.shouldNotBeNull
 import org.spekframework.spek2.Spek


### PR DESCRIPTION
Flytter disse til infrastructure.database.repository for å skille det fra database-config-filene.