### PR TITLE
IS-2094-3: Setup varsel expired topic, define record to publish

### DIFF
--- a/.github/workflows/kafka-arbeidsuforhet.yaml
+++ b/.github/workflows/kafka-arbeidsuforhet.yaml
@@ -1,0 +1,40 @@
+name: kafka
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '.github/workflows/kafka-arbeidsuforhet.yaml'
+      - '.nais/kafka/**'
+
+permissions:
+  id-token: write
+
+jobs:
+  deploy-kafka-arbeidsuforhet-dev:
+    name: Deploy Kafka topics to dev-gcp
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Deploy arbeidsuforhet-expired-varsel topic to dev
+        uses: nais/deploy/actions/deploy@v2
+        env:
+          CLUSTER: dev-gcp
+          RESOURCE: .nais/kafka/arbeidsuforhet-expired-varsel.yaml
+          VARS: .nais/kafka/dev.json
+
+  deploy-kafka-arbeidsuforhet-prod:
+    name: Deploy Kafka topics to prod-gcp
+    needs: deploy-kafka-arbeidsuforhet-dev
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Deploy arbeidsuforhet-expired-varsel topic to prod
+        uses: nais/deploy/actions/deploy@v2
+        env:
+          CLUSTER: prod-gcp
+          RESOURCE: .nais/kafka/arbeidsuforhet-expired-varsel.yaml
+          VARS: .nais/kafka/prod.json

--- a/.nais/kafka/arbeidsuforhet-expired-varsel.yaml
+++ b/.nais/kafka/arbeidsuforhet-expired-varsel.yaml
@@ -2,7 +2,7 @@ apiVersion: kafka.nais.io/v1
 kind: Topic
 metadata:
   annotations:
-    dcat.data.nav.no/title: "Utgatt forhåndsvarsel om stopp på sykepenger for arbeidsuforhet sykmeldte personer"
+    dcat.data.nav.no/title: "Utgatt forhåndsvarsel om avslag på sykepenger for arbeidsuforhet sykmeldte personer"
     dcat.data.nav.no/description: >-
       Topic inneholder informasjon om et forhåndsvarsel der svarfrist har gatt ut.
   name: arbeidsuforhet-expired-forhandsvarsel

--- a/.nais/kafka/arbeidsuforhet-expired-varsel.yaml
+++ b/.nais/kafka/arbeidsuforhet-expired-varsel.yaml
@@ -1,0 +1,27 @@
+apiVersion: kafka.nais.io/v1
+kind: Topic
+metadata:
+  annotations:
+    dcat.data.nav.no/title: "Utgatt forhåndsvarsel om stopp på sykepenger for arbeidsuforhet sykmeldte personer"
+    dcat.data.nav.no/description: >-
+      Topic inneholder informasjon om et forhåndsvarsel der svarfrist har gatt ut.
+  name: arbeidsuforhet-expired-forhandsvarsel
+  namespace: teamsykefravr
+  labels:
+    team: teamsykefravr
+spec:
+  pool: {{ kafkaPool }}
+  config:
+    cleanupPolicy: delete
+    minimumInSyncReplicas: 1
+    partitions: 4
+    replication: 3
+    retentionBytes: -1  # -1 means unlimited
+    retentionHours: -1  # -1 means unlimited
+  acl:
+    - team: teamsykefravr
+      application: isarbeidsuforhet
+      access: readwrite
+    - team: teamsykefravr
+      application: ispersonoppgave
+      access: read

--- a/.nais/kafka/dev.json
+++ b/.nais/kafka/dev.json
@@ -1,0 +1,3 @@
+{
+  "kafkaPool": "nav-dev"
+}

--- a/.nais/kafka/prod.json
+++ b/.nais/kafka/prod.json
@@ -1,0 +1,3 @@
+{
+  "kafkaPool": "nav-prod"
+}

--- a/src/main/kotlin/no/nav/syfo/infrastructure/kafka/ExpiredForhandsvarselProducer.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/kafka/ExpiredForhandsvarselProducer.kt
@@ -6,9 +6,10 @@ import no.nav.syfo.domain.Varsel
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.slf4j.LoggerFactory
+import java.time.OffsetDateTime
 import java.util.*
 
-class ExpiredForhandsvarselProducer(private val producer: KafkaProducer<String, Varsel>) :
+class ExpiredForhandsvarselProducer(private val producer: KafkaProducer<String, ExpiredForhandsvarselRecord>) :
     IExpiredForhandsvarselProducer {
 
     override fun send(personIdent: PersonIdent, varsel: Varsel): Result<Varsel> =
@@ -17,7 +18,7 @@ class ExpiredForhandsvarselProducer(private val producer: KafkaProducer<String, 
                 ProducerRecord(
                     TOPIC,
                     UUID.randomUUID().toString(),
-                    varsel,
+                    ExpiredForhandsvarselRecord.fromVarsel(personIdent, varsel),
                 )
             ).get()
             Result.success(varsel)
@@ -29,5 +30,22 @@ class ExpiredForhandsvarselProducer(private val producer: KafkaProducer<String, 
     companion object {
         private const val TOPIC = "teamsykefravr.arbeidsuforhet-expired-forhandsvarsel"
         private val log = LoggerFactory.getLogger(ExpiredForhandsvarselProducer::class.java)
+    }
+}
+
+data class ExpiredForhandsvarselRecord(
+    val uuid: UUID,
+    val createdAt: OffsetDateTime,
+    val personIdent: PersonIdent,
+    val svarfrist: OffsetDateTime,
+) {
+    companion object {
+        fun fromVarsel(personIdent: PersonIdent, varsel: Varsel): ExpiredForhandsvarselRecord =
+            ExpiredForhandsvarselRecord(
+                uuid = varsel.uuid,
+                createdAt = varsel.createdAt,
+                personIdent = personIdent,
+                svarfrist = varsel.svarfrist,
+            )
     }
 }

--- a/src/main/kotlin/no/nav/syfo/infrastructure/kafka/ExpiredForhandsvarselRecordSerializer.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/kafka/ExpiredForhandsvarselRecordSerializer.kt
@@ -1,11 +1,10 @@
 package no.nav.syfo.infrastructure.kafka
 
-import no.nav.syfo.domain.Varsel
 import no.nav.syfo.util.configuredJacksonMapper
 import org.apache.kafka.common.serialization.Serializer
 
-class ExpiredForhandsvarselRecordSerializer : Serializer<Varsel> {
+class ExpiredForhandsvarselRecordSerializer : Serializer<ExpiredForhandsvarselRecord> {
     private val mapper = configuredJacksonMapper()
-    override fun serialize(topic: String?, data: Varsel?): ByteArray =
+    override fun serialize(topic: String?, data: ExpiredForhandsvarselRecord?): ByteArray =
         mapper.writeValueAsBytes(data)
 }

--- a/src/test/kotlin/no/nav/syfo/application/service/VarselServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/application/service/VarselServiceSpek.kt
@@ -13,6 +13,7 @@ import no.nav.syfo.infrastructure.database.repository.VarselRepository
 import no.nav.syfo.infrastructure.database.repository.VurderingRepository
 import no.nav.syfo.infrastructure.journalforing.JournalforingService
 import no.nav.syfo.infrastructure.kafka.ExpiredForhandsvarselProducer
+import no.nav.syfo.infrastructure.kafka.ExpiredForhandsvarselRecord
 import no.nav.syfo.infrastructure.kafka.esyfovarsel.ArbeidstakerForhandsvarselProducer
 import no.nav.syfo.infrastructure.kafka.esyfovarsel.dto.ArbeidstakerHendelse
 import no.nav.syfo.infrastructure.kafka.esyfovarsel.dto.EsyfovarselHendelse
@@ -41,7 +42,7 @@ class VarselServiceSpek : Spek({
         val varselRepository = VarselRepository(database = database)
         val vurderingRepository = VurderingRepository(database = database)
         val mockEsyfoVarselHendelseProducer = mockk<KafkaProducer<String, EsyfovarselHendelse>>()
-        val mockExpiredForhandsvarselProducer = mockk<KafkaProducer<String, Varsel>>()
+        val mockExpiredForhandsvarselProducer = mockk<KafkaProducer<String, ExpiredForhandsvarselRecord>>()
 
         val varselProducer = ArbeidstakerForhandsvarselProducer(kafkaProducer = mockEsyfoVarselHendelseProducer)
         val expiredForhandsvarselProducer =
@@ -152,7 +153,7 @@ class VarselServiceSpek : Spek({
                 failed.size shouldBeEqualTo 0
                 success.size shouldBeEqualTo 1
 
-                val producerRecordSlot = slot<ProducerRecord<String, Varsel>>()
+                val producerRecordSlot = slot<ProducerRecord<String, ExpiredForhandsvarselRecord>>()
                 verify(exactly = 1) { mockExpiredForhandsvarselProducer.send(capture(producerRecordSlot)) }
 
                 val publishedExpiredVarsel = success.first().getOrThrow()
@@ -162,7 +163,7 @@ class VarselServiceSpek : Spek({
 
                 varselRepository.getUnpublishedVarsler().shouldBeEmpty()
 
-                val publishedExpiredVarselRecord = producerRecordSlot.captured.value() as Varsel
+                val publishedExpiredVarselRecord = producerRecordSlot.captured.value() as ExpiredForhandsvarselRecord
                 publishedExpiredVarselRecord.uuid shouldBeEqualTo expiredUnpublishedVarsel.uuid
             }
 


### PR DESCRIPTION
- Oppretter `teamsykefravr.arbeidsuforhet-expired-forhandsvarsel` topic
- Definerer første utgave av utgått varsel record som blir publisert på kafka. Utifra hva jeg kan se i `ispersonoppgave` for hvordan recorden til et utgått varsel for aktivitetskrav ser ut, så brukes bare `varselUuid`, `personIdent`, `varselType`. `varselType` stemmer jeg for at vi legger på om/når vi trenger det 😊 Bare å foreslå andre felter vi trenger, eventuelt felter vi ikke trenger.