### PR TITLE
IS-2047: Ikke tillate duplikate FORHANDSVARSEL

### DIFF
--- a/src/main/kotlin/no/nav/syfo/api/endpoints/ArbeidsuforhetEndpoints.kt
+++ b/src/main/kotlin/no/nav/syfo/api/endpoints/ArbeidsuforhetEndpoints.kt
@@ -8,6 +8,7 @@ import io.ktor.server.routing.*
 import no.nav.syfo.api.model.ForhandsvarselRequestDTO
 import no.nav.syfo.api.model.VurderingResponseDTO
 import no.nav.syfo.application.service.VurderingService
+import no.nav.syfo.domain.VurderingType
 import no.nav.syfo.infrastructure.NAV_PERSONIDENT_HEADER
 import no.nav.syfo.infrastructure.clients.veiledertilgang.VeilederTilgangskontrollClient
 import no.nav.syfo.infrastructure.clients.veiledertilgang.VeilederTilgangskontrollPlugin
@@ -52,7 +53,12 @@ fun Route.registerArbeidsuforhetEndpoints(
                 ?: throw IllegalArgumentException("Failed to $API_ACTION: No $NAV_PERSONIDENT_HEADER supplied in request header")
             val navIdent = call.getNAVIdent()
             val callId = call.getCallId()
-
+            val existingVurderinger = vurderingService.getVurderinger(
+                personident = personIdent,
+            )
+            if (existingVurderinger.firstOrNull()?.type == VurderingType.FORHANDSVARSEL) {
+                throw IllegalArgumentException("Duplicate FORHANDSVARSEL for given person")
+            }
             val newForhandsvarselVurdering = vurderingService.createForhandsvarsel(
                 personident = personIdent,
                 veilederident = navIdent,

--- a/src/test/kotlin/no/nav/syfo/api/endpoints/ArbeidsuforhetEndpointsSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/api/endpoints/ArbeidsuforhetEndpointsSpek.kt
@@ -107,6 +107,27 @@ object ArbeidsuforhetEndpointsSpek : Spek({
                             pVurderingPdf?.pdf?.get(1) shouldBeEqualTo PDF_FORHANDSVARSEL[1]
                         }
                     }
+                    it("Does not allow duplicate forhandsvarsel") {
+                        runBlocking {
+                            vurderingService.createForhandsvarsel(
+                                personident = PersonIdent(personIdent),
+                                veilederident = VEILEDER_IDENT,
+                                begrunnelse = begrunnelse,
+                                document = document,
+                                callId = UUID.randomUUID().toString(),
+                            )
+                        }
+                        with(
+                            handleRequest(HttpMethod.Post, urlForhandsvarsel) {
+                                addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                                addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
+                                addHeader(NAV_PERSONIDENT_HEADER, personIdent)
+                                setBody(objectMapper.writeValueAsString(forhandsvarselRequestDTO))
+                            }
+                        ) {
+                            response.status() shouldBeEqualTo HttpStatusCode.BadRequest
+                        }
+                    }
                     it("Successfully gets an existing vurdering") {
                         runBlocking {
                             vurderingService.createForhandsvarsel(


### PR DESCRIPTION
Fikk registrert duplikate forhåndsvarsel før i dag. Bør tilpasses på klientsiden også, men backend bør heller ikke tillate dette.