### PR TITLE
IS-2139: Add create-vurdering endpoint

### DIFF
--- a/src/main/kotlin/no/nav/syfo/api/model/VurderingRequestDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/api/model/VurderingRequestDTO.kt
@@ -1,0 +1,10 @@
+package no.nav.syfo.api.model
+
+import no.nav.syfo.domain.DocumentComponent
+import no.nav.syfo.domain.VurderingType
+
+data class VurderingRequestDTO(
+    val type: VurderingType,
+    val begrunnelse: String,
+    val document: List<DocumentComponent>,
+)

--- a/src/main/kotlin/no/nav/syfo/application/IJournalforingService.kt
+++ b/src/main/kotlin/no/nav/syfo/application/IJournalforingService.kt
@@ -1,12 +1,12 @@
 package no.nav.syfo.application
 
 import no.nav.syfo.domain.PersonIdent
-import java.util.*
+import no.nav.syfo.domain.Vurdering
 
 interface IJournalforingService {
     suspend fun journalfor(
         personident: PersonIdent,
         pdf: ByteArray,
-        vurderingUUID: UUID,
+        vurdering: Vurdering,
     ): Int
 }

--- a/src/main/kotlin/no/nav/syfo/application/IVurderingPdfService.kt
+++ b/src/main/kotlin/no/nav/syfo/application/IVurderingPdfService.kt
@@ -1,12 +1,10 @@
 package no.nav.syfo.application
 
-import no.nav.syfo.domain.DocumentComponent
-import no.nav.syfo.domain.PersonIdent
+import no.nav.syfo.domain.Vurdering
 
 interface IVurderingPdfService {
     suspend fun createVurderingPdf(
-        personident: PersonIdent,
-        document: List<DocumentComponent>,
+        vurdering: Vurdering,
         callId: String,
     ): ByteArray
 }

--- a/src/main/kotlin/no/nav/syfo/application/IVurderingRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/application/IVurderingRepository.kt
@@ -10,6 +10,11 @@ interface IVurderingRepository {
 
     fun getUnpublishedVurderinger(): List<Vurdering>
 
+    fun createVurdering(
+        vurdering: Vurdering,
+        pdf: ByteArray?
+    ): Vurdering
+
     fun createForhandsvarsel(
         pdf: ByteArray,
         vurdering: Vurdering,

--- a/src/main/kotlin/no/nav/syfo/application/service/VurderingService.kt
+++ b/src/main/kotlin/no/nav/syfo/application/service/VurderingService.kt
@@ -7,6 +7,7 @@ import no.nav.syfo.application.IVurderingRepository
 import no.nav.syfo.domain.Vurdering
 import no.nav.syfo.domain.DocumentComponent
 import no.nav.syfo.domain.PersonIdent
+import no.nav.syfo.domain.VurderingType
 
 class VurderingService(
     private val vurderingRepository: IVurderingRepository,
@@ -19,6 +20,36 @@ class VurderingService(
         personident: PersonIdent,
     ): List<Vurdering> = vurderingRepository.getVurderinger(personident)
 
+    suspend fun createVurdering(
+        personident: PersonIdent,
+        veilederident: String,
+        type: VurderingType,
+        begrunnelse: String,
+        document: List<DocumentComponent>,
+        callId: String,
+    ): Vurdering {
+        val vurdering = Vurdering(
+            personident = personident,
+            veilederident = veilederident,
+            begrunnelse = begrunnelse,
+            document = document,
+            type = type,
+        )
+        val pdf = if (vurdering.shouldJournalfores()) {
+            vurderingPdfService.createVurderingPdf(
+                vurdering = vurdering,
+                callId = callId,
+            )
+        } else null
+
+        vurderingRepository.createVurdering(
+            vurdering = vurdering,
+            pdf = pdf,
+        )
+
+        return vurdering
+    }
+
     suspend fun createForhandsvarsel(
         personident: PersonIdent,
         veilederident: String,
@@ -26,17 +57,16 @@ class VurderingService(
         document: List<DocumentComponent>,
         callId: String,
     ): Vurdering {
-        val pdf = vurderingPdfService.createVurderingPdf(
-            personident = personident,
-            document = document,
-            callId = callId,
-        )
         val vurdering = Vurdering.createForhandsvarsel(
             personident = personident,
             veilederident = veilederident,
             begrunnelse = begrunnelse,
             document = document,
             svarfristDager = svarfristDager,
+        )
+        val pdf = vurderingPdfService.createVurderingPdf(
+            vurdering = vurdering,
+            callId = callId,
         )
 
         vurderingRepository.createForhandsvarsel(
@@ -55,7 +85,7 @@ class VurderingService(
                 val journalpostId = journalforingService.journalfor(
                     personident = vurdering.personident,
                     pdf = pdf,
-                    vurderingUUID = vurdering.uuid,
+                    vurdering = vurdering,
                 )
                 val journalfortVurdering = vurdering.journalfor(
                     journalpostId = journalpostId.toString(),

--- a/src/main/kotlin/no/nav/syfo/infrastructure/clients/dokarkiv/dto/Dokument.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/clients/dokarkiv/dto/Dokument.kt
@@ -4,6 +4,7 @@ enum class BrevkodeType(
     val value: String,
 ) {
     ARBEIDSUFORHET_FORHANDSVARSEL("OPPF_ARBEIDSUFORHET_FORHANDSVARSEL"),
+    ARBEIDSUFORHET_VURDERING("OPPF_ARBEIDSUFORHET_VURDERING")
 }
 
 data class Dokument private constructor(

--- a/src/main/kotlin/no/nav/syfo/infrastructure/clients/dokarkiv/dto/JournalpostRequest.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/clients/dokarkiv/dto/JournalpostRequest.kt
@@ -4,6 +4,7 @@ const val JOURNALFORENDE_ENHET = 9999
 
 enum class JournalpostType {
     UTGAAENDE,
+    NOTAT,
 }
 
 enum class JournalpostTema(val value: String) {

--- a/src/main/kotlin/no/nav/syfo/infrastructure/clients/pdfgen/PdfGenClient.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/clients/pdfgen/PdfGenClient.kt
@@ -29,6 +29,16 @@ class PdfGenClient(
             pdfUrl = "$pdfGenBaseUrl$API_BASE_PATH$FORHANDSVARSEL_PATH"
         ) ?: throw RuntimeException("Failed to request pdf for forhandsvarsel, callId: $callId")
 
+    suspend fun createOppfyltPdf(
+        callId: String,
+        oppfyltPdfDTO: VurderingPdfDTO,
+    ): ByteArray =
+        getPdf(
+            callId = callId,
+            payload = oppfyltPdfDTO,
+            pdfUrl = "$pdfGenBaseUrl$API_BASE_PATH$OPPFYLT_PATH"
+        ) ?: throw RuntimeException("Failed to request pdf for vurdering oppfylt, callId: $callId")
+
     private suspend inline fun <reified Payload> getPdf(
         callId: String,
         payload: Payload,
@@ -67,6 +77,7 @@ class PdfGenClient(
     companion object {
         private const val API_BASE_PATH = "/api/v1/genpdf/isarbeidsuforhet"
         const val FORHANDSVARSEL_PATH = "/forhandsvarsel-om-avslag-pa-sykepenger"
+        const val OPPFYLT_PATH = "/vurdering-av-arbeidsuforhet"
 
         private val log = LoggerFactory.getLogger(PdfGenClient::class.java)
     }

--- a/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/VurderingRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/VurderingRepository.kt
@@ -45,6 +45,23 @@ class VurderingRepository(private val database: DatabaseInterface) : IVurderingR
             }
         }
 
+    override fun createVurdering(vurdering: Vurdering, pdf: ByteArray?): Vurdering {
+        database.connection.use { connection ->
+            val pVurdering = connection.createVurdering(vurdering)
+            if (pdf != null) {
+                connection.createPdf(
+                    vurderingId = pVurdering.id,
+                    pdf = pdf,
+                )
+            }
+            connection.commit()
+
+            return pVurdering.toVurdering(
+                varsel = connection.getVarselForVurdering(pVurdering)
+            )
+        }
+    }
+
     override fun createForhandsvarsel(
         pdf: ByteArray,
         vurdering: Vurdering,
@@ -173,7 +190,7 @@ class VurderingRepository(private val database: DatabaseInterface) : IVurderingR
 
         private const val UPDATE_VURDERING =
             """
-                UPDATE VURDERING SET journalpost_id=?, updated_at=?, published_at=? WHERE uuid=? 
+                UPDATE VURDERING SET journalpost_id=?, updated_at=?, published_at=? WHERE uuid=?
             """
 
         private const val CREATE_VARSEL =

--- a/src/test/kotlin/no/nav/syfo/UserConstants.kt
+++ b/src/test/kotlin/no/nav/syfo/UserConstants.kt
@@ -11,11 +11,13 @@ object UserConstants {
     val ARBEIDSTAKER_PERSONIDENT_PDL_FAILS = PersonIdent("11111111666")
 
     val PDF_FORHANDSVARSEL = byteArrayOf(0x2E, 0x28)
+    val PDF_OPPFYLT = byteArrayOf(0x2E, 0x30)
     const val VEILEDER_IDENT = "Z999999"
 
     const val PERSON_FORNAVN = "Fornavn"
     const val PERSON_MELLOMNAVN = "Mellomnavn"
     const val PERSON_ETTERNAVN = "Etternavnesen"
+    const val PERSON_FULLNAME = "Fornavn Mellomnavn Etternavnesen"
     const val PERSON_FORNAVN_DASH = "For-Navn"
     const val PERSON_FULLNAME_DASH = "For-Navn Mellomnavn Etternavnesen"
 

--- a/src/test/kotlin/no/nav/syfo/api/endpoints/ArbeidsuforhetEndpointsSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/api/endpoints/ArbeidsuforhetEndpointsSpek.kt
@@ -9,9 +9,11 @@ import kotlinx.coroutines.runBlocking
 import no.nav.syfo.ExternalMockEnvironment
 import no.nav.syfo.UserConstants.ARBEIDSTAKER_PERSONIDENT
 import no.nav.syfo.UserConstants.PDF_FORHANDSVARSEL
+import no.nav.syfo.UserConstants.PDF_OPPFYLT
 import no.nav.syfo.UserConstants.VEILEDER_IDENT
 import no.nav.syfo.api.*
 import no.nav.syfo.api.model.ForhandsvarselRequestDTO
+import no.nav.syfo.api.model.VurderingRequestDTO
 import no.nav.syfo.api.model.VurderingResponseDTO
 import no.nav.syfo.application.IVurderingProducer
 import no.nav.syfo.application.service.VurderingService
@@ -69,14 +71,14 @@ object ArbeidsuforhetEndpointsSpek : Spek({
                 issuer = externalMockEnvironment.wellKnownInternalAzureAD.issuer,
                 navIdent = VEILEDER_IDENT,
             )
-            val begrunnelse = "Dette er en begrunnelse for forhåndsvarsel 8-4"
-            val document = generateDocumentComponent(
+            val begrunnelse = "Dette er en begrunnelse for vurdering av 8-4"
+            val forhandsvarselDocument = generateDocumentComponent(
                 fritekst = begrunnelse,
                 header = "Forhåndsvarsel"
             )
             val forhandsvarselRequestDTO = ForhandsvarselRequestDTO(
                 begrunnelse = begrunnelse,
-                document = document,
+                document = forhandsvarselDocument,
             )
             val personIdent = ARBEIDSTAKER_PERSONIDENT.value
 
@@ -101,11 +103,13 @@ object ArbeidsuforhetEndpointsSpek : Spek({
                             responseDTO.begrunnelse shouldBeEqualTo begrunnelse
                             responseDTO.personident shouldBeEqualTo ARBEIDSTAKER_PERSONIDENT.value
                             responseDTO.veilederident shouldBeEqualTo VEILEDER_IDENT
-                            responseDTO.document shouldBeEqualTo document
+                            responseDTO.document shouldBeEqualTo forhandsvarselDocument
+                            responseDTO.type shouldBeEqualTo VurderingType.FORHANDSVARSEL
 
                             val vurdering = vurderingRepository.getVurderinger(ARBEIDSTAKER_PERSONIDENT).firstOrNull()
                             vurdering?.begrunnelse shouldBeEqualTo begrunnelse
                             vurdering?.personident shouldBeEqualTo ARBEIDSTAKER_PERSONIDENT
+                            vurdering?.type shouldBeEqualTo VurderingType.FORHANDSVARSEL
 
                             val pVurderingPdf = database.getVurderingPdf(vurdering!!.uuid)
                             pVurderingPdf?.pdf?.size shouldBeEqualTo PDF_FORHANDSVARSEL.size
@@ -119,7 +123,7 @@ object ArbeidsuforhetEndpointsSpek : Spek({
                                 personident = PersonIdent(personIdent),
                                 veilederident = VEILEDER_IDENT,
                                 begrunnelse = begrunnelse,
-                                document = document,
+                                document = forhandsvarselDocument,
                                 callId = UUID.randomUUID().toString(),
                             )
                         }
@@ -140,7 +144,7 @@ object ArbeidsuforhetEndpointsSpek : Spek({
                                 personident = PersonIdent(personIdent),
                                 veilederident = VEILEDER_IDENT,
                                 begrunnelse = begrunnelse,
-                                document = document,
+                                document = forhandsvarselDocument,
                                 callId = UUID.randomUUID().toString(),
                             )
                         }
@@ -159,7 +163,7 @@ object ArbeidsuforhetEndpointsSpek : Spek({
                             responseDTO.begrunnelse shouldBeEqualTo begrunnelse
                             responseDTO.personident shouldBeEqualTo ARBEIDSTAKER_PERSONIDENT.value
                             responseDTO.veilederident shouldBeEqualTo VEILEDER_IDENT
-                            responseDTO.document shouldBeEqualTo document
+                            responseDTO.document shouldBeEqualTo forhandsvarselDocument
                             responseDTO.type shouldBeEqualTo VurderingType.FORHANDSVARSEL
                             responseDTO.varsel.shouldNotBeNull()
                             responseDTO.varsel?.svarFrist shouldBeEqualTo LocalDate.now().plusWeeks(3)
@@ -184,14 +188,14 @@ object ArbeidsuforhetEndpointsSpek : Spek({
                                 personident = PersonIdent(personIdent),
                                 veilederident = VEILEDER_IDENT,
                                 begrunnelse = begrunnelse,
-                                document = document,
+                                document = forhandsvarselDocument,
                                 callId = UUID.randomUUID().toString(),
                             )
                             vurderingService.createForhandsvarsel(
                                 personident = PersonIdent(personIdent),
                                 veilederident = VEILEDER_IDENT,
                                 begrunnelse = begrunnelse,
-                                document = document,
+                                document = forhandsvarselDocument,
                                 callId = UUID.randomUUID().toString(),
                             )
                         }
@@ -246,6 +250,116 @@ object ArbeidsuforhetEndpointsSpek : Spek({
                     }
                     it("Returns status BadRequest if $NAV_PERSONIDENT_HEADER with invalid PersonIdent is supplied") {
                         testInvalidPersonIdent(urlVurdering, validToken, HttpMethod.Get)
+                    }
+                }
+            }
+
+            describe("Vurdering") {
+                val vurderingDocumentOppfylt = generateDocumentComponent(
+                    fritekst = begrunnelse,
+                    header = "Oppfylt",
+                )
+                val vurderingRequestDTO = VurderingRequestDTO(
+                    type = VurderingType.OPPFYLT,
+                    begrunnelse = begrunnelse,
+                    document = vurderingDocumentOppfylt,
+                )
+                describe("Happy path") {
+                    it("Creates new vurdering OPPFYLT and creates PDF") {
+                        with(
+                            handleRequest(HttpMethod.Post, urlVurdering) {
+                                addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                                addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
+                                addHeader(NAV_PERSONIDENT_HEADER, personIdent)
+                                setBody(objectMapper.writeValueAsString(vurderingRequestDTO))
+                            }
+                        ) {
+                            response.status() shouldBeEqualTo HttpStatusCode.Created
+
+                            val responseDTO = objectMapper.readValue<VurderingResponseDTO>(response.content!!)
+                            responseDTO.begrunnelse shouldBeEqualTo begrunnelse
+                            responseDTO.personident shouldBeEqualTo ARBEIDSTAKER_PERSONIDENT.value
+                            responseDTO.veilederident shouldBeEqualTo VEILEDER_IDENT
+                            responseDTO.document shouldBeEqualTo vurderingDocumentOppfylt
+                            responseDTO.type shouldBeEqualTo VurderingType.OPPFYLT
+
+                            val vurdering = vurderingRepository.getVurderinger(ARBEIDSTAKER_PERSONIDENT).firstOrNull()
+                            vurdering?.begrunnelse shouldBeEqualTo begrunnelse
+                            vurdering?.personident shouldBeEqualTo ARBEIDSTAKER_PERSONIDENT
+                            vurdering?.type shouldBeEqualTo VurderingType.OPPFYLT
+
+                            val pVurderingPdf = database.getVurderingPdf(vurdering!!.uuid)
+                            pVurderingPdf?.pdf?.size shouldBeEqualTo PDF_OPPFYLT.size
+                            pVurderingPdf?.pdf?.get(0) shouldBeEqualTo PDF_OPPFYLT[0]
+                            pVurderingPdf?.pdf?.get(1) shouldBeEqualTo PDF_OPPFYLT[1]
+                        }
+                    }
+
+                    it("Creates new vurdering AVSLAG and does not create PDF") {
+                        val vurderingDocumentAvslag = generateDocumentComponent(
+                            fritekst = begrunnelse,
+                            header = "Avslag",
+                        )
+                        val vurderingAvslagRequestDTO = VurderingRequestDTO(
+                            type = VurderingType.AVSLAG,
+                            begrunnelse = begrunnelse,
+                            document = vurderingDocumentAvslag,
+                        )
+                        with(
+                            handleRequest(HttpMethod.Post, urlVurdering) {
+                                addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                                addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
+                                addHeader(NAV_PERSONIDENT_HEADER, personIdent)
+                                setBody(objectMapper.writeValueAsString(vurderingAvslagRequestDTO))
+                            }
+                        ) {
+                            response.status() shouldBeEqualTo HttpStatusCode.Created
+
+                            val responseDTO = objectMapper.readValue<VurderingResponseDTO>(response.content!!)
+                            responseDTO.begrunnelse shouldBeEqualTo begrunnelse
+                            responseDTO.personident shouldBeEqualTo ARBEIDSTAKER_PERSONIDENT.value
+                            responseDTO.veilederident shouldBeEqualTo VEILEDER_IDENT
+                            responseDTO.document shouldBeEqualTo vurderingDocumentAvslag
+                            responseDTO.type shouldBeEqualTo VurderingType.AVSLAG
+
+                            val vurdering = vurderingRepository.getVurderinger(ARBEIDSTAKER_PERSONIDENT).firstOrNull()
+                            vurdering?.begrunnelse shouldBeEqualTo begrunnelse
+                            vurdering?.personident shouldBeEqualTo ARBEIDSTAKER_PERSONIDENT
+                            vurdering?.type shouldBeEqualTo VurderingType.AVSLAG
+
+                            val pVurderingPdf = database.getVurderingPdf(vurdering!!.uuid)
+                            pVurderingPdf shouldBeEqualTo null
+                        }
+                    }
+                }
+
+                describe("Unhappy path") {
+                    it("Throws error when document is empty") {
+                        val vurderingWithoutDocument = vurderingRequestDTO.copy(document = emptyList())
+                        with(
+                            handleRequest(HttpMethod.Post, urlVurdering) {
+                                addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                                addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
+                                addHeader(NAV_PERSONIDENT_HEADER, personIdent)
+                                setBody(objectMapper.writeValueAsString(vurderingWithoutDocument))
+                            }
+                        ) {
+                            response.status() shouldBeEqualTo HttpStatusCode.BadRequest
+                        }
+                    }
+
+                    it("Throws error when begrunnelse is empty") {
+                        val vurderingWithoutBegrunnelse = vurderingRequestDTO.copy(begrunnelse = "")
+                        with(
+                            handleRequest(HttpMethod.Post, urlVurdering) {
+                                addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                                addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
+                                addHeader(NAV_PERSONIDENT_HEADER, personIdent)
+                                setBody(objectMapper.writeValueAsString(vurderingWithoutBegrunnelse))
+                            }
+                        ) {
+                            response.status() shouldBeEqualTo HttpStatusCode.BadRequest
+                        }
                     }
                 }
             }

--- a/src/test/kotlin/no/nav/syfo/application/service/ForhandsvarselServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/application/service/ForhandsvarselServiceSpek.kt
@@ -21,11 +21,11 @@ object ForhandsvarselServiceSpek : Spek({
 
     describe(ForhandsvarselServiceSpek::class.java.simpleName) {
         val vurderingRepositoryMock = mockk<IVurderingRepository>(relaxed = true)
-        val varselPdfServiceMock = mockk<IVurderingPdfService>(relaxed = true)
+        val vurderingPdfServiceMock = mockk<IVurderingPdfService>(relaxed = true)
         val journalforingServiceMock = mockk<IJournalforingService>(relaxed = true)
         val vurderingService = VurderingService(
             vurderingRepository = vurderingRepositoryMock,
-            vurderingPdfService = varselPdfServiceMock,
+            vurderingPdfService = vurderingPdfServiceMock,
             journalforingService = journalforingServiceMock,
             vurderingProducer = mockk<IVurderingProducer>(),
             svarfristDager = 21,
@@ -37,7 +37,7 @@ object ForhandsvarselServiceSpek : Spek({
                 vurderingRepositoryMock.createForhandsvarsel(any(), any())
             } returns Unit
             coEvery {
-                varselPdfServiceMock.createVurderingPdf(any(), any(), any())
+                vurderingPdfServiceMock.createVurderingPdf(any(), any())
             } returns PDF_FORHANDSVARSEL
             coEvery {
                 journalforingServiceMock.journalfor(any(), any(), any())
@@ -64,9 +64,8 @@ object ForhandsvarselServiceSpek : Spek({
                         vurdering.veilederident shouldBeEqualTo VEILEDER_IDENT
 
                         coVerify(exactly = 1) {
-                            varselPdfServiceMock.createVurderingPdf(
-                                personident = ARBEIDSTAKER_PERSONIDENT,
-                                document = document,
+                            vurderingPdfServiceMock.createVurderingPdf(
+                                vurdering = vurdering,
                                 callId = "",
                             )
                         }
@@ -98,7 +97,7 @@ object ForhandsvarselServiceSpek : Spek({
                         }
 
                         coVerify(exactly = 1) {
-                            varselPdfServiceMock.createVurderingPdf(any(), any(), any())
+                            vurderingPdfServiceMock.createVurderingPdf(any(), any())
                         }
                         coVerify(exactly = 1) {
                             vurderingRepositoryMock.createForhandsvarsel(any(), any())
@@ -108,7 +107,7 @@ object ForhandsvarselServiceSpek : Spek({
 
                 it("Fails when pdfGen fails") {
                     coEvery {
-                        varselPdfServiceMock.createVurderingPdf(any(), any(), any())
+                        vurderingPdfServiceMock.createVurderingPdf(any(), any())
                     } throws RuntimeException("Could not create pdf")
 
                     runBlocking {
@@ -123,7 +122,7 @@ object ForhandsvarselServiceSpek : Spek({
                         }
 
                         coVerify(exactly = 1) {
-                            varselPdfServiceMock.createVurderingPdf(any(), any(), any())
+                            vurderingPdfServiceMock.createVurderingPdf(any(), any())
                         }
                         coVerify(exactly = 0) {
                             vurderingRepositoryMock.createForhandsvarsel(any(), any())

--- a/src/test/kotlin/no/nav/syfo/generator/JournalpostRequestGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/generator/JournalpostRequestGenerator.kt
@@ -8,13 +8,13 @@ fun generateJournalpostRequest(
     tittel: String,
     brevkodeType: BrevkodeType,
     pdf: ByteArray,
-    varselId: UUID,
+    vurderingUuid: UUID,
     journalpostType: String = JournalpostType.UTGAAENDE.name,
 ) = JournalpostRequest(
     avsenderMottaker = AvsenderMottaker.create(
         id = UserConstants.ARBEIDSTAKER_PERSONIDENT.value,
         idType = BrukerIdType.PERSON_IDENT,
-        navn = UserConstants.PERSON_FULLNAME_DASH,
+        navn = UserConstants.PERSON_FULLNAME,
     ),
     bruker = Bruker.create(
         id = UserConstants.ARBEIDSTAKER_PERSONIDENT.value,
@@ -36,5 +36,5 @@ fun generateJournalpostRequest(
         )
     ),
     journalpostType = journalpostType,
-    eksternReferanseId = varselId.toString(),
+    eksternReferanseId = vurderingUuid.toString(),
 )

--- a/src/test/kotlin/no/nav/syfo/generator/VurderingGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/generator/VurderingGenerator.kt
@@ -14,3 +14,16 @@ fun generateForhandsvarselVurdering(
     document = document,
     svarfristDager = 21,
 )
+
+fun generateVurdering(
+    personident: PersonIdent = UserConstants.ARBEIDSTAKER_PERSONIDENT,
+    begrunnelse: String = "En begrunnelse",
+    document: List<DocumentComponent> = generateDocumentComponent(begrunnelse),
+    type: VurderingType,
+) = Vurdering(
+    personident = personident,
+    veilederident = UserConstants.VEILEDER_IDENT,
+    begrunnelse = begrunnelse,
+    document = document,
+    type = type,
+)

--- a/src/test/kotlin/no/nav/syfo/infrastructure/dokarkiv/DokarkivClientSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/dokarkiv/DokarkivClientSpek.kt
@@ -19,12 +19,12 @@ class DokarkivClientSpek : Spek({
 
     describe(DokarkivClient::class.java.simpleName) {
 
-        it("journalfører aktivitetskrav") {
+        it("journalfører forhåndsvarsel") {
             val journalpostRequestForhandsvarsel = generateJournalpostRequest(
                 tittel = "Forhåndsvarsel om avslag på sykepenger",
                 brevkodeType = BrevkodeType.ARBEIDSUFORHET_FORHANDSVARSEL,
                 pdf = PDF_FORHANDSVARSEL,
-                varselId = UUID.randomUUID(),
+                vurderingUuid = UUID.randomUUID(),
             )
 
             runBlocking {
@@ -41,7 +41,7 @@ class DokarkivClientSpek : Spek({
                 tittel = "Forhåndsvarsel om avslag på sykepenger",
                 brevkodeType = BrevkodeType.ARBEIDSUFORHET_FORHANDSVARSEL,
                 pdf = PDF_FORHANDSVARSEL,
-                varselId = EXISTING_EKSTERN_REFERANSE_UUID,
+                vurderingUuid = EXISTING_EKSTERN_REFERANSE_UUID,
             )
 
             runBlocking {

--- a/src/test/kotlin/no/nav/syfo/infrastructure/journalforing/JournalforingServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/journalforing/JournalforingServiceSpek.kt
@@ -1,0 +1,110 @@
+package no.nav.syfo.infrastructure.journalforing
+
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import no.nav.syfo.ExternalMockEnvironment
+import no.nav.syfo.UserConstants.ARBEIDSTAKER_PERSONIDENT
+import no.nav.syfo.UserConstants.PDF_FORHANDSVARSEL
+import no.nav.syfo.UserConstants.PDF_OPPFYLT
+import no.nav.syfo.domain.VurderingType
+import no.nav.syfo.domain.getBrevkode
+import no.nav.syfo.domain.getDokumentTittel
+import no.nav.syfo.domain.getJournalpostType
+import no.nav.syfo.generator.generateForhandsvarselVurdering
+import no.nav.syfo.generator.generateJournalpostRequest
+import no.nav.syfo.generator.generateVurdering
+import no.nav.syfo.infrastructure.clients.dokarkiv.DokarkivClient
+import no.nav.syfo.infrastructure.mock.dokarkivResponse
+import no.nav.syfo.infrastructure.mock.mockedJournalpostId
+import org.amshove.kluent.internal.assertFailsWith
+import org.amshove.kluent.shouldBeEqualTo
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+object JournalforingServiceSpek : Spek({
+    describe(JournalforingService::class.java.simpleName) {
+
+        val externalMockEnvironment = ExternalMockEnvironment.instance
+        val dokarkivMock = mockk<DokarkivClient>(relaxed = true)
+        val journalforingService = JournalforingService(
+            dokarkivClient = dokarkivMock,
+            pdlClient = externalMockEnvironment.pdlClient,
+        )
+
+        val vurderingOppfylt = generateVurdering(type = VurderingType.OPPFYLT)
+        val vurderingAvslag = generateVurdering(type = VurderingType.AVSLAG)
+        val vurderingForhandsvarsel = generateForhandsvarselVurdering()
+
+        beforeEachTest {
+            clearAllMocks()
+            coEvery { dokarkivMock.journalfor(any()) } returns dokarkivResponse
+        }
+
+        describe("Journalføring") {
+            it("Journalfører OPPFYLT vurdering") {
+                runBlocking {
+                    val journalpostId = journalforingService.journalfor(
+                        personident = ARBEIDSTAKER_PERSONIDENT,
+                        pdf = PDF_OPPFYLT,
+                        vurdering = vurderingOppfylt,
+                    )
+
+                    journalpostId shouldBeEqualTo mockedJournalpostId
+
+                    coVerify(exactly = 1) {
+                        dokarkivMock.journalfor(
+                            journalpostRequest = generateJournalpostRequest(
+                                tittel = VurderingType.OPPFYLT.getDokumentTittel(),
+                                brevkodeType = VurderingType.OPPFYLT.getBrevkode(),
+                                pdf = PDF_OPPFYLT,
+                                vurderingUuid = vurderingOppfylt.uuid,
+                                journalpostType = VurderingType.OPPFYLT.getJournalpostType().name,
+                            )
+                        )
+                    }
+                }
+            }
+
+            it("Journalfører FORHANDSVARSEL vurdering") {
+                runBlocking {
+                    val journalpostId = journalforingService.journalfor(
+                        personident = ARBEIDSTAKER_PERSONIDENT,
+                        pdf = PDF_FORHANDSVARSEL,
+                        vurdering = vurderingForhandsvarsel,
+                    )
+
+                    journalpostId shouldBeEqualTo mockedJournalpostId
+
+                    coVerify(exactly = 1) {
+                        dokarkivMock.journalfor(
+                            journalpostRequest = generateJournalpostRequest(
+                                tittel = VurderingType.FORHANDSVARSEL.getDokumentTittel(),
+                                brevkodeType = VurderingType.FORHANDSVARSEL.getBrevkode(),
+                                pdf = PDF_FORHANDSVARSEL,
+                                vurderingUuid = vurderingForhandsvarsel.uuid,
+                                journalpostType = VurderingType.FORHANDSVARSEL.getJournalpostType().name,
+                            )
+                        )
+                    }
+                }
+            }
+
+            it("Journalfører ikke når AVSLAG vurdering") {
+                runBlocking {
+                    assertFailsWith<IllegalStateException> {
+                        journalforingService.journalfor(
+                            personident = ARBEIDSTAKER_PERSONIDENT,
+                            pdf = byteArrayOf(0x2E, 0x21),
+                            vurdering = vurderingAvslag,
+                        )
+                    }
+
+                    coVerify(exactly = 0) { dokarkivMock.journalfor(any()) }
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/no/nav/syfo/infrastructure/mock/DokarkivMock.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/mock/DokarkivMock.kt
@@ -7,8 +7,9 @@ import no.nav.syfo.UserConstants
 import no.nav.syfo.infrastructure.clients.dokarkiv.dto.JournalpostRequest
 import no.nav.syfo.infrastructure.clients.dokarkiv.dto.JournalpostResponse
 
+const val mockedJournalpostId = 1
 val dokarkivResponse = JournalpostResponse(
-    journalpostId = 1,
+    journalpostId = mockedJournalpostId,
     journalpostferdigstilt = true,
     journalstatus = "status",
 )

--- a/src/test/kotlin/no/nav/syfo/infrastructure/mock/PdfGenClientMock.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/mock/PdfGenClientMock.kt
@@ -12,6 +12,10 @@ fun MockRequestHandleScope.pdfGenClientMockResponse(request: HttpRequestData): H
         requestUrl.endsWith(PdfGenClient.Companion.FORHANDSVARSEL_PATH) -> {
             respond(content = UserConstants.PDF_FORHANDSVARSEL)
         }
+        requestUrl.endsWith(PdfGenClient.Companion.OPPFYLT_PATH) -> {
+            respond(content = UserConstants.PDF_OPPFYLT)
+        }
+
         else -> error("Unhandled pdf ${request.url.encodedPath}")
     }
 }


### PR DESCRIPTION
Se slacktråd for info om hvilke vurderinger som skal journalføres og ikke: https://nav-it.slack.com/archives/C06HMAY0ELA/p1709560585048279

Kort fortalt: `OPPFYLT` og `FORHANDSVARSEL` skal journalføres, ikke `AVSLAG`.
Logikken rundt journalføring er inspirert av https://github.com/navikt/isaktivitetskrav/blob/master/src/main/kotlin/no/nav/syfo/aktivitetskrav/domain/VarselType.kt#L13

Vi må etterhvert definere hvordan Oppfylt-dokumentet skal se ut i og oppdatere endepunkt i pdf-gen.