### PR TITLE
Bruker String som type på personident på kafka-dto

### DIFF
--- a/src/main/kotlin/no/nav/syfo/infrastructure/kafka/VurderingProducer.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/kafka/VurderingProducer.kt
@@ -1,7 +1,6 @@
 package no.nav.syfo.infrastructure.kafka
 
 import no.nav.syfo.application.IVurderingProducer
-import no.nav.syfo.domain.PersonIdent
 import no.nav.syfo.domain.Vurdering
 import no.nav.syfo.domain.VurderingType
 import org.apache.kafka.clients.producer.KafkaProducer

--- a/src/main/kotlin/no/nav/syfo/infrastructure/kafka/VurderingProducer.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/kafka/VurderingProducer.kt
@@ -37,7 +37,7 @@ class VurderingProducer(private val producer: KafkaProducer<String, VurderingRec
 data class VurderingRecord(
     val uuid: UUID,
     val createdAt: OffsetDateTime,
-    val personident: PersonIdent,
+    val personident: String,
     val veilederident: String,
     val type: VurderingType,
     val begrunnelse: String,
@@ -47,7 +47,7 @@ data class VurderingRecord(
             VurderingRecord(
                 uuid = vurdering.uuid,
                 createdAt = vurdering.createdAt,
-                personident = vurdering.personident,
+                personident = vurdering.personident.value,
                 veilederident = vurdering.veilederident,
                 type = vurdering.type,
                 begrunnelse = vurdering.begrunnelse,


### PR DESCRIPTION
Unngår at vi wrapper value i et objekt og gjør det likt som andre kafka-dtoer.