### PR TITLE
IS-2180: Add svarfrist to varsel response dto

### DIFF
--- a/src/main/kotlin/no/nav/syfo/api/model/VurderingResponseDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/api/model/VurderingResponseDTO.kt
@@ -4,6 +4,7 @@ import no.nav.syfo.domain.DocumentComponent
 import no.nav.syfo.domain.Varsel
 import no.nav.syfo.domain.Vurdering
 import no.nav.syfo.domain.VurderingType
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -26,7 +27,7 @@ data class VurderingResponseDTO private constructor(
             type = vurdering.type,
             begrunnelse = vurdering.begrunnelse,
             document = vurdering.document,
-            varsel = if (vurdering.varsel == null) null else VarselDTO.createFromVarsel(vurdering.varsel),
+            varsel = vurdering.varsel?.let { VarselDTO.createFromVarsel(it) },
         )
     }
 }
@@ -34,11 +35,13 @@ data class VurderingResponseDTO private constructor(
 data class VarselDTO private constructor(
     val uuid: UUID,
     val createdAt: LocalDateTime,
+    val svarFrist: LocalDate,
 ) {
     companion object {
         fun createFromVarsel(varsel: Varsel) = VarselDTO(
             uuid = varsel.uuid,
             createdAt = varsel.createdAt.toLocalDateTime(),
+            svarFrist = varsel.svarfrist,
         )
     }
 }

--- a/src/test/kotlin/no/nav/syfo/api/endpoints/ArbeidsuforhetEndpointsSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/api/endpoints/ArbeidsuforhetEndpointsSpek.kt
@@ -27,8 +27,10 @@ import no.nav.syfo.infrastructure.database.getVurderingPdf
 import no.nav.syfo.infrastructure.journalforing.JournalforingService
 import no.nav.syfo.util.configuredJacksonMapper
 import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldNotBeNull
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
+import java.time.LocalDate
 import java.util.*
 
 object ArbeidsuforhetEndpointsSpek : Spek({
@@ -158,6 +160,8 @@ object ArbeidsuforhetEndpointsSpek : Spek({
                             responseDTO.veilederident shouldBeEqualTo VEILEDER_IDENT
                             responseDTO.document shouldBeEqualTo document
                             responseDTO.type shouldBeEqualTo VurderingType.FORHANDSVARSEL
+                            responseDTO.varsel.shouldNotBeNull()
+                            responseDTO.varsel?.svarFrist shouldBeEqualTo LocalDate.now().plusWeeks(3)
                         }
                     }
                     it("Successfully gets empty list of vurderinger") {


### PR DESCRIPTION
Sånn at vi kan bruke dette til å vise fristen i frontend i stedet for å ha utregningen der også.