### PR TITLE
IS-2155: Add varsel does not publish if oppfylt after varsel created

### DIFF
--- a/src/main/kotlin/no/nav/syfo/domain/Vurdering.kt
+++ b/src/main/kotlin/no/nav/syfo/domain/Vurdering.kt
@@ -15,7 +15,6 @@ data class Vurdering private constructor(
     val document: List<DocumentComponent>,
     val journalpostId: String?,
     val publishedAt: OffsetDateTime?,
-
 ) {
     fun journalfor(journalpostId: String): Vurdering = this.copy(journalpostId = journalpostId)
 

--- a/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/VarselRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/VarselRepository.kt
@@ -72,6 +72,13 @@ class VarselRepository(private val database: DatabaseInterface) : IVarselReposit
                 INNER JOIN vurdering vu
                 ON v.vurdering_id = vu.id
                 WHERE svarfrist <= NOW() AND svarfrist_expired_published_at IS NULL
+                    AND NOT EXISTS (
+                        SELECT 1
+                        FROM vurdering vu2
+                        WHERE vu2.id = v.vurdering_id
+                            AND vu2.created_at > v.created_at
+                            AND vu2.type IN ('OPPFYLT')
+                )
             """
 
         private const val GET_VURDERING =

--- a/src/test/kotlin/no/nav/syfo/infrastructure/database/VarselRepositorySpek.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/database/VarselRepositorySpek.kt
@@ -25,20 +25,15 @@ class VarselRepositorySpek : Spek({
             }
 
             val expiredVarselOneWeekAgo =
-                Varsel()
-                    .copy(svarfrist = LocalDate.now().minusWeeks(1))
+                Varsel().copy(svarfrist = LocalDate.now().minusWeeks(1))
             val expiredVarselYesterday =
-                Varsel()
-                    .copy(svarfrist = LocalDate.now().minusDays(1))
+                Varsel().copy(svarfrist = LocalDate.now().minusDays(1))
             val expiredVarselToday =
-                Varsel()
-                    .copy(svarfrist = LocalDate.now())
+                Varsel().copy(svarfrist = LocalDate.now())
             val expiredVarselTomorrow =
-                Varsel()
-                    .copy(svarfrist = LocalDate.now().plusDays(1))
+                Varsel().copy(svarfrist = LocalDate.now().plusDays(1))
             val expiredVarselInOneWeek =
-                Varsel()
-                    .copy(svarfrist = LocalDate.now().plusWeeks(1))
+                Varsel().copy(svarfrist = LocalDate.now().plusWeeks(1))
 
             it("retrieves expired varsler") {
                 val vurderinger = listOf(


### PR DESCRIPTION
- Legger til at man ikke publiserer utgått varsel om man har en vurdering `OPPFYLT` på samme person etter varselet har blitt laget.
- Her skulle vi hatt en test for å teste at man ikke henter ut varselet om det ligger en vurdering oppfylt, men finnes ikke funksjonalitet for dette enda.