### PR TITLE
Refactor sendArbeidstakerForhandsvarsel and rename cronjob

### DIFF
--- a/src/main/kotlin/no/nav/syfo/application/IVarselProducer.kt
+++ b/src/main/kotlin/no/nav/syfo/application/IVarselProducer.kt
@@ -2,9 +2,12 @@ package no.nav.syfo.application
 
 import no.nav.syfo.domain.PersonIdent
 import no.nav.syfo.domain.Varsel
-import no.nav.syfo.domain.Vurdering
 
 interface IVarselProducer {
-    fun sendArbeidstakerForhandsvarsel(personIdent: PersonIdent, vurdering: Vurdering): Result<Varsel>
+    fun sendArbeidstakerForhandsvarsel(
+        personIdent: PersonIdent,
+        journalpostId: String,
+        varsel: Varsel
+    ): Result<Varsel>
     fun sendExpiredForhandsvarsel(personIdent: PersonIdent, varsel: Varsel): Result<Varsel>
 }

--- a/src/main/kotlin/no/nav/syfo/application/IVarselProducer.kt
+++ b/src/main/kotlin/no/nav/syfo/application/IVarselProducer.kt
@@ -1,12 +1,13 @@
 package no.nav.syfo.application
 
+import no.nav.syfo.domain.JournalpostId
 import no.nav.syfo.domain.PersonIdent
 import no.nav.syfo.domain.Varsel
 
 interface IVarselProducer {
     fun sendArbeidstakerForhandsvarsel(
         personIdent: PersonIdent,
-        journalpostId: String,
+        journalpostId: JournalpostId,
         varsel: Varsel
     ): Result<Varsel>
     fun sendExpiredForhandsvarsel(personIdent: PersonIdent, varsel: Varsel): Result<Varsel>

--- a/src/main/kotlin/no/nav/syfo/application/IVarselRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/application/IVarselRepository.kt
@@ -2,11 +2,9 @@ package no.nav.syfo.application
 
 import no.nav.syfo.domain.PersonIdent
 import no.nav.syfo.domain.Varsel
-import no.nav.syfo.domain.Vurdering
 
 interface IVarselRepository {
-    fun getUnpublishedVarsler(): List<Pair<PersonIdent, Varsel>>
+    fun getUnpublishedVarsler(): List<Triple<PersonIdent, String, Varsel>>
     fun getUnpublishedExpiredVarsler(): List<Pair<PersonIdent, Varsel>>
     fun update(varsel: Varsel)
-    fun getVurdering(varsel: Varsel): Vurdering?
 }

--- a/src/main/kotlin/no/nav/syfo/application/IVarselRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/application/IVarselRepository.kt
@@ -1,10 +1,11 @@
 package no.nav.syfo.application
 
+import no.nav.syfo.domain.JournalpostId
 import no.nav.syfo.domain.PersonIdent
 import no.nav.syfo.domain.Varsel
 
 interface IVarselRepository {
-    fun getUnpublishedVarsler(): List<Triple<PersonIdent, String, Varsel>>
+    fun getUnpublishedVarsler(): List<Triple<PersonIdent, JournalpostId, Varsel>>
     fun getUnpublishedExpiredVarsler(): List<Pair<PersonIdent, Varsel>>
     fun update(varsel: Varsel)
 }

--- a/src/main/kotlin/no/nav/syfo/application/service/VarselService.kt
+++ b/src/main/kotlin/no/nav/syfo/application/service/VarselService.kt
@@ -10,10 +10,12 @@ class VarselService(
 ) {
     fun publishUnpublishedVarsler(): List<Result<Varsel>> {
         val unpublishedVarsler = varselRepository.getUnpublishedVarsler()
-        return unpublishedVarsler.map { (personident, varsel) ->
-            val vurdering = varselRepository.getVurdering(varsel)
-                ?: throw IllegalStateException("varsel should always have a vurdering")
-            val result = varselProducer.sendArbeidstakerForhandsvarsel(personIdent = personident, vurdering = vurdering)
+        return unpublishedVarsler.map { (personident, journalpostId, varsel) ->
+            val result = varselProducer.sendArbeidstakerForhandsvarsel(
+                personIdent = personident,
+                journalpostId = journalpostId,
+                varsel = varsel,
+            )
             result.map {
                 val publishedVarsel = varsel.publish()
                 varselRepository.update(publishedVarsel)

--- a/src/main/kotlin/no/nav/syfo/application/service/VurderingService.kt
+++ b/src/main/kotlin/no/nav/syfo/application/service/VurderingService.kt
@@ -4,10 +4,7 @@ import no.nav.syfo.application.IJournalforingService
 import no.nav.syfo.application.IVurderingPdfService
 import no.nav.syfo.application.IVurderingProducer
 import no.nav.syfo.application.IVurderingRepository
-import no.nav.syfo.domain.Vurdering
-import no.nav.syfo.domain.DocumentComponent
-import no.nav.syfo.domain.PersonIdent
-import no.nav.syfo.domain.VurderingType
+import no.nav.syfo.domain.*
 
 class VurderingService(
     private val vurderingRepository: IVurderingRepository,
@@ -88,7 +85,7 @@ class VurderingService(
                     vurdering = vurdering,
                 )
                 val journalfortVurdering = vurdering.journalfor(
-                    journalpostId = journalpostId.toString(),
+                    journalpostId = JournalpostId(journalpostId.toString()),
                 )
                 vurderingRepository.update(journalfortVurdering)
 

--- a/src/main/kotlin/no/nav/syfo/domain/JournalpostId.kt
+++ b/src/main/kotlin/no/nav/syfo/domain/JournalpostId.kt
@@ -1,0 +1,10 @@
+package no.nav.syfo.domain
+
+@JvmInline
+value class JournalpostId(val value: String) {
+    init {
+        if (value.toDoubleOrNull() == null) {
+            throw IllegalArgumentException("Value is not a valid JournalpostId")
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/domain/JournalpostId.kt
+++ b/src/main/kotlin/no/nav/syfo/domain/JournalpostId.kt
@@ -3,7 +3,7 @@ package no.nav.syfo.domain
 @JvmInline
 value class JournalpostId(val value: String) {
     init {
-        if (value.toDoubleOrNull() == null) {
+        if (!value.all { it.isDigit() }) {
             throw IllegalArgumentException("Value is not a valid JournalpostId")
         }
     }

--- a/src/main/kotlin/no/nav/syfo/domain/Vurdering.kt
+++ b/src/main/kotlin/no/nav/syfo/domain/Vurdering.kt
@@ -15,7 +15,7 @@ data class Vurdering private constructor(
     val begrunnelse: String,
     val varsel: Varsel?,
     val document: List<DocumentComponent>,
-    val journalpostId: String?,
+    val journalpostId: JournalpostId?,
     val publishedAt: OffsetDateTime?,
 ) {
 
@@ -39,7 +39,7 @@ data class Vurdering private constructor(
         publishedAt = null,
     )
 
-    fun journalfor(journalpostId: String): Vurdering = this.copy(journalpostId = journalpostId)
+    fun journalfor(journalpostId: JournalpostId): Vurdering = this.copy(journalpostId = journalpostId)
 
     fun publish(): Vurdering = this.copy(publishedAt = nowUTC())
 
@@ -76,7 +76,7 @@ data class Vurdering private constructor(
             type: String,
             begrunnelse: String,
             document: List<DocumentComponent>,
-            journalpostId: String?,
+            journalpostId: JournalpostId?,
             varsel: Varsel?,
             publishedAt: OffsetDateTime?,
         ) = Vurdering(

--- a/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/CronjobModule.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/CronjobModule.kt
@@ -22,8 +22,8 @@ fun launchCronjobs(
     )
     val cronjobs = mutableListOf<Cronjob>()
 
-    val journalforForhandsvarselCronjob = JournalforForhandsvarselCronjob(vurderingService)
-    cronjobs.add(journalforForhandsvarselCronjob)
+    val journalforVurderingerCronjob = JournalforVurderingerCronjob(vurderingService)
+    cronjobs.add(journalforVurderingerCronjob)
 
     val publishForhandsvarselCronjob = PublishForhandsvarselCronjob(varselService = varselService)
     cronjobs.add(publishForhandsvarselCronjob)

--- a/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/JournalforVurderingerCronjob.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/JournalforVurderingerCronjob.kt
@@ -4,7 +4,7 @@ import net.logstash.logback.argument.StructuredArguments
 import no.nav.syfo.application.service.VurderingService
 import org.slf4j.LoggerFactory
 
-class JournalforForhandsvarselCronjob(
+class JournalforVurderingerCronjob(
     private val vurderingService: VurderingService,
 ) : Cronjob {
     override val initialDelayMinutes: Long = 2
@@ -13,16 +13,16 @@ class JournalforForhandsvarselCronjob(
     override suspend fun run() {
         val (success, failed) = vurderingService.journalforVurderinger().partition { it.isSuccess }
         failed.forEach {
-            log.error("Exception caught while journalforing forhandsvarsel", it.exceptionOrNull())
+            log.error("Exception caught while journalforing vurdering", it.exceptionOrNull())
         }
         log.info(
-            "Completed journalforing forhandsvarsel with result: {}, {}",
+            "Completed journalforing vurdering with result: {}, {}",
             StructuredArguments.keyValue("failed", failed.size),
             StructuredArguments.keyValue("updated", success.size),
         )
     }
 
     companion object {
-        private val log = LoggerFactory.getLogger(JournalforForhandsvarselCronjob::class.java)
+        private val log = LoggerFactory.getLogger(JournalforVurderingerCronjob::class.java)
     }
 }

--- a/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/PVurdering.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/PVurdering.kt
@@ -1,9 +1,6 @@
 package no.nav.syfo.infrastructure.database.repository
 
-import no.nav.syfo.domain.DocumentComponent
-import no.nav.syfo.domain.PersonIdent
-import no.nav.syfo.domain.Varsel
-import no.nav.syfo.domain.Vurdering
+import no.nav.syfo.domain.*
 import java.time.OffsetDateTime
 import java.util.UUID
 
@@ -31,7 +28,7 @@ data class PVurdering(
         type = type,
         begrunnelse = begrunnelse,
         document = document,
-        journalpostId = journalpostId,
+        journalpostId = journalpostId?.let { JournalpostId(it) },
         varsel = varsel,
         publishedAt = publishedAt,
     )

--- a/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/VarselRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/VarselRepository.kt
@@ -3,7 +3,6 @@ package no.nav.syfo.infrastructure.database.repository
 import no.nav.syfo.application.IVarselRepository
 import no.nav.syfo.domain.PersonIdent
 import no.nav.syfo.domain.Varsel
-import no.nav.syfo.domain.Vurdering
 import no.nav.syfo.infrastructure.database.DatabaseInterface
 import no.nav.syfo.infrastructure.database.toList
 import no.nav.syfo.util.nowUTC
@@ -14,11 +13,11 @@ import java.util.*
 
 class VarselRepository(private val database: DatabaseInterface) : IVarselRepository {
 
-    override fun getUnpublishedVarsler(): List<Pair<PersonIdent, Varsel>> = database.connection.use { connection ->
+    override fun getUnpublishedVarsler(): List<Triple<PersonIdent, String, Varsel>> = database.connection.use { connection ->
         connection.prepareStatement(GET_UNPUBLISHED_VARSEL).use {
-            it.executeQuery().toList { Pair(PersonIdent(getString("personident")), toPVarsel()) }
+            it.executeQuery().toList { Triple(PersonIdent(getString("personident")), getString("journalpost_id"), toPVarsel()) }
         }
-    }.map { (personident, pVarsel) -> Pair(personident, pVarsel.toVarsel()) }
+    }.map { (personident, journalpostId, pVarsel) -> Triple(personident, journalpostId, pVarsel.toVarsel()) }
 
     override fun getUnpublishedExpiredVarsler(): List<Pair<PersonIdent, Varsel>> =
         database.connection.use { connection ->
@@ -41,18 +40,10 @@ class VarselRepository(private val database: DatabaseInterface) : IVarselReposit
         connection.commit()
     }
 
-    override fun getVurdering(varsel: Varsel): Vurdering? =
-        database.connection.use { connection ->
-            connection.prepareStatement(GET_VURDERING).use {
-                it.setString(1, varsel.uuid.toString())
-                it.executeQuery().toList { toPVurdering() }.firstOrNull()?.toVurdering(varsel)
-            }
-        }
-
     companion object {
         private const val GET_UNPUBLISHED_VARSEL =
             """
-                SELECT vu.personident, v.* FROM varsel v
+                SELECT vu.personident, vu.journalpost_id, v.* FROM varsel v
                 INNER JOIN vurdering vu
                 ON v.vurdering_id = vu.id
                 WHERE vu.journalpost_id IS NOT NULL AND v.published_at IS NULL
@@ -72,13 +63,6 @@ class VarselRepository(private val database: DatabaseInterface) : IVarselReposit
                 INNER JOIN vurdering vu
                 ON v.vurdering_id = vu.id
                 WHERE svarfrist <= NOW() AND v.published_at IS NOT NULL AND svarfrist_expired_published_at IS NULL
-            """
-
-        private const val GET_VURDERING =
-            """
-                SELECT vu.* FROM vurdering vu 
-                INNER JOIN varsel v ON v.vurdering_id=vu.id 
-                WHERE v.uuid=?
             """
     }
 }

--- a/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/VarselRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/VarselRepository.kt
@@ -1,6 +1,7 @@
 package no.nav.syfo.infrastructure.database.repository
 
 import no.nav.syfo.application.IVarselRepository
+import no.nav.syfo.domain.JournalpostId
 import no.nav.syfo.domain.PersonIdent
 import no.nav.syfo.domain.Varsel
 import no.nav.syfo.infrastructure.database.DatabaseInterface
@@ -13,9 +14,9 @@ import java.util.*
 
 class VarselRepository(private val database: DatabaseInterface) : IVarselRepository {
 
-    override fun getUnpublishedVarsler(): List<Triple<PersonIdent, String, Varsel>> = database.connection.use { connection ->
+    override fun getUnpublishedVarsler(): List<Triple<PersonIdent, JournalpostId, Varsel>> = database.connection.use { connection ->
         connection.prepareStatement(GET_UNPUBLISHED_VARSEL).use {
-            it.executeQuery().toList { Triple(PersonIdent(getString("personident")), getString("journalpost_id"), toPVarsel()) }
+            it.executeQuery().toList { Triple(PersonIdent(getString("personident")), JournalpostId(getString("journalpost_id")), toPVarsel()) }
         }
     }.map { (personident, journalpostId, pVarsel) -> Triple(personident, journalpostId, pVarsel.toVarsel()) }
 

--- a/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/VurderingRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/VurderingRepository.kt
@@ -2,10 +2,7 @@ package no.nav.syfo.infrastructure.database.repository
 
 import com.fasterxml.jackson.core.type.TypeReference
 import no.nav.syfo.application.IVurderingRepository
-import no.nav.syfo.domain.DocumentComponent
-import no.nav.syfo.domain.PersonIdent
-import no.nav.syfo.domain.Varsel
-import no.nav.syfo.domain.Vurdering
+import no.nav.syfo.domain.*
 import no.nav.syfo.infrastructure.database.DatabaseInterface
 import no.nav.syfo.infrastructure.database.toList
 import no.nav.syfo.util.configuredJacksonMapper
@@ -84,7 +81,7 @@ class VurderingRepository(private val database: DatabaseInterface) : IVurderingR
 
     override fun update(vurdering: Vurdering) = database.connection.use { connection ->
         connection.prepareStatement(UPDATE_VURDERING).use {
-            it.setString(1, vurdering.journalpostId)
+            it.setString(1, vurdering.journalpostId?.value)
             it.setObject(2, nowUTC())
             it.setObject(3, vurdering.publishedAt)
             it.setString(4, vurdering.uuid.toString())

--- a/src/main/kotlin/no/nav/syfo/infrastructure/kafka/VarselProducer.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/kafka/VarselProducer.kt
@@ -1,6 +1,7 @@
 package no.nav.syfo.infrastructure.kafka
 
 import no.nav.syfo.application.IVarselProducer
+import no.nav.syfo.domain.JournalpostId
 import no.nav.syfo.domain.PersonIdent
 import no.nav.syfo.domain.Varsel
 import no.nav.syfo.infrastructure.kafka.esyfovarsel.ArbeidstakerForhandsvarselProducer
@@ -12,7 +13,7 @@ class VarselProducer(
 
     override fun sendArbeidstakerForhandsvarsel(
         personIdent: PersonIdent,
-        journalpostId: String,
+        journalpostId: JournalpostId,
         varsel: Varsel
     ): Result<Varsel> {
         return arbeidstakerForhandsvarselProducer.sendArbeidstakerForhandsvarsel(personIdent = personIdent, journalpostId = journalpostId, varsel = varsel)

--- a/src/main/kotlin/no/nav/syfo/infrastructure/kafka/VarselProducer.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/kafka/VarselProducer.kt
@@ -3,7 +3,6 @@ package no.nav.syfo.infrastructure.kafka
 import no.nav.syfo.application.IVarselProducer
 import no.nav.syfo.domain.PersonIdent
 import no.nav.syfo.domain.Varsel
-import no.nav.syfo.domain.Vurdering
 import no.nav.syfo.infrastructure.kafka.esyfovarsel.ArbeidstakerForhandsvarselProducer
 
 class VarselProducer(
@@ -11,8 +10,12 @@ class VarselProducer(
     private val expiredForhandsvarselProducer: ExpiredForhandsvarselProducer
 ) : IVarselProducer {
 
-    override fun sendArbeidstakerForhandsvarsel(personIdent: PersonIdent, vurdering: Vurdering): Result<Varsel> {
-        return arbeidstakerForhandsvarselProducer.sendArbeidstakerForhandsvarsel(personIdent = personIdent, vurdering = vurdering)
+    override fun sendArbeidstakerForhandsvarsel(
+        personIdent: PersonIdent,
+        journalpostId: String,
+        varsel: Varsel
+    ): Result<Varsel> {
+        return arbeidstakerForhandsvarselProducer.sendArbeidstakerForhandsvarsel(personIdent = personIdent, journalpostId = journalpostId, varsel = varsel)
     }
 
     override fun sendExpiredForhandsvarsel(personIdent: PersonIdent, varsel: Varsel): Result<Varsel> {

--- a/src/main/kotlin/no/nav/syfo/infrastructure/kafka/esyfovarsel/ArbeidstakerForhandsvarselProducer.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/kafka/esyfovarsel/ArbeidstakerForhandsvarselProducer.kt
@@ -2,7 +2,6 @@ package no.nav.syfo.infrastructure.kafka.esyfovarsel
 
 import no.nav.syfo.domain.PersonIdent
 import no.nav.syfo.domain.Varsel
-import no.nav.syfo.domain.Vurdering
 import no.nav.syfo.infrastructure.kafka.esyfovarsel.dto.*
 import java.util.*
 import org.apache.kafka.clients.producer.KafkaProducer
@@ -11,14 +10,14 @@ import org.slf4j.LoggerFactory
 
 class ArbeidstakerForhandsvarselProducer(private val kafkaProducer: KafkaProducer<String, EsyfovarselHendelse>) {
 
-    fun sendArbeidstakerForhandsvarsel(personIdent: PersonIdent, vurdering: Vurdering): Result<Varsel> {
+    fun sendArbeidstakerForhandsvarsel(personIdent: PersonIdent, journalpostId: String, varsel: Varsel): Result<Varsel> {
         val varselHendelse = ArbeidstakerHendelse(
             type = HendelseType.SM_ARBEIDSUFORHET_FORHANDSVARSEL,
             arbeidstakerFnr = personIdent.value,
             data = VarselData(
                 journalpost = VarselDataJournalpost(
-                    uuid = vurdering.varsel!!.uuid.toString(),
-                    id = vurdering.journalpostId,
+                    uuid = varsel.uuid.toString(),
+                    id = journalpostId,
                 ),
             ),
             orgnummer = null,
@@ -32,7 +31,7 @@ class ArbeidstakerForhandsvarselProducer(private val kafkaProducer: KafkaProduce
                     varselHendelse,
                 )
             ).get()
-            return Result.success(vurdering.varsel)
+            return Result.success(varsel)
         } catch (e: Exception) {
             log.error("Exception was thrown when attempting to send hendelse to esyfovarsel: ${e.message}")
             return Result.failure(e)

--- a/src/main/kotlin/no/nav/syfo/infrastructure/kafka/esyfovarsel/ArbeidstakerForhandsvarselProducer.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/kafka/esyfovarsel/ArbeidstakerForhandsvarselProducer.kt
@@ -1,5 +1,6 @@
 package no.nav.syfo.infrastructure.kafka.esyfovarsel
 
+import no.nav.syfo.domain.JournalpostId
 import no.nav.syfo.domain.PersonIdent
 import no.nav.syfo.domain.Varsel
 import no.nav.syfo.infrastructure.kafka.esyfovarsel.dto.*
@@ -10,14 +11,14 @@ import org.slf4j.LoggerFactory
 
 class ArbeidstakerForhandsvarselProducer(private val kafkaProducer: KafkaProducer<String, EsyfovarselHendelse>) {
 
-    fun sendArbeidstakerForhandsvarsel(personIdent: PersonIdent, journalpostId: String, varsel: Varsel): Result<Varsel> {
+    fun sendArbeidstakerForhandsvarsel(personIdent: PersonIdent, journalpostId: JournalpostId, varsel: Varsel): Result<Varsel> {
         val varselHendelse = ArbeidstakerHendelse(
             type = HendelseType.SM_ARBEIDSUFORHET_FORHANDSVARSEL,
             arbeidstakerFnr = personIdent.value,
             data = VarselData(
                 journalpost = VarselDataJournalpost(
                     uuid = varsel.uuid.toString(),
-                    id = journalpostId,
+                    id = journalpostId.value,
                 ),
             ),
             orgnummer = null,

--- a/src/test/kotlin/no/nav/syfo/application/service/VarselServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/application/service/VarselServiceSpek.kt
@@ -3,6 +3,7 @@ package no.nav.syfo.application.service
 import io.mockk.*
 import no.nav.syfo.ExternalMockEnvironment
 import no.nav.syfo.UserConstants
+import no.nav.syfo.domain.JournalpostId
 import no.nav.syfo.domain.Varsel
 import no.nav.syfo.generator.generateForhandsvarselVurdering
 import no.nav.syfo.infrastructure.database.dropData
@@ -28,7 +29,7 @@ import org.spekframework.spek2.style.specification.describe
 import java.time.OffsetDateTime
 import java.util.concurrent.Future
 
-private const val journalpostId = "123"
+private val journalpostId = JournalpostId("123")
 
 class VarselServiceSpek : Spek({
     describe(VarselService::class.java.simpleName) {
@@ -117,7 +118,7 @@ class VarselServiceSpek : Spek({
                 esyfovarselHendelse.arbeidstakerFnr.shouldBeEqualTo(UserConstants.ARBEIDSTAKER_PERSONIDENT.value)
                 val varselData = esyfovarselHendelse.data as VarselData
                 varselData.journalpost?.uuid.shouldBeEqualTo(publishedVarsel.uuid.toString())
-                varselData.journalpost?.id!!.shouldBeEqualTo(journalpostId)
+                varselData.journalpost?.id!!.shouldBeEqualTo(journalpostId.value)
             }
 
             it("publishes nothing when no unpublished varsel") {

--- a/src/test/kotlin/no/nav/syfo/application/service/VarselServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/application/service/VarselServiceSpek.kt
@@ -138,7 +138,7 @@ class VarselServiceSpek : Spek({
 
                 verify(exactly = 1) { mockEsyfoVarselHendelseProducer.send(any()) }
 
-                val (_, varsel) = varselRepository.getUnpublishedVarsler().first()
+                val (_, _, varsel) = varselRepository.getUnpublishedVarsler().first()
                 varsel.uuid.shouldBeEqualTo(unpublishedVarsel.uuid)
             }
         }

--- a/src/test/kotlin/no/nav/syfo/application/service/VurderingServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/application/service/VurderingServiceSpek.kt
@@ -7,6 +7,7 @@ import no.nav.syfo.UserConstants
 import no.nav.syfo.UserConstants.ARBEIDSTAKER_PERSONIDENT
 import no.nav.syfo.UserConstants.PDF_OPPFYLT
 import no.nav.syfo.UserConstants.VEILEDER_IDENT
+import no.nav.syfo.domain.JournalpostId
 import no.nav.syfo.domain.VurderingType
 import no.nav.syfo.generator.generateDocumentComponent
 import no.nav.syfo.generator.generateForhandsvarselVurdering
@@ -86,7 +87,7 @@ class VurderingServiceSpek : Spek({
                 success.size shouldBeEqualTo 1
 
                 val journalfortVurdering = success.first().getOrThrow()
-                journalfortVurdering.journalpostId shouldBeEqualTo mockedJournalpostId.toString()
+                journalfortVurdering.journalpostId?.value shouldBeEqualTo mockedJournalpostId.toString()
 
                 val pVurdering = database.getVurdering(journalfortVurdering.uuid)
                 pVurdering!!.updatedAt shouldBeGreaterThan pVurdering.createdAt
@@ -110,7 +111,7 @@ class VurderingServiceSpek : Spek({
                 success.size shouldBeEqualTo 1
 
                 val journalfortVurdering = success.first().getOrThrow()
-                journalfortVurdering.journalpostId shouldBeEqualTo mockedJournalpostId.toString()
+                journalfortVurdering.journalpostId?.value shouldBeEqualTo mockedJournalpostId.toString()
 
                 val pVurdering = database.getVurdering(journalfortVurdering.uuid)
                 pVurdering!!.updatedAt shouldBeGreaterThan pVurdering.createdAt
@@ -133,7 +134,7 @@ class VurderingServiceSpek : Spek({
                     pdf = UserConstants.PDF_FORHANDSVARSEL,
                     vurdering = vurderingForhandsvarsel,
                 )
-                val journalfortVarsel = vurderingForhandsvarsel.journalfor(journalpostId = mockedJournalpostId.toString())
+                val journalfortVarsel = vurderingForhandsvarsel.journalfor(journalpostId = JournalpostId(mockedJournalpostId.toString()))
                 vurderingRepository.update(journalfortVarsel)
 
                 val journalforteVurderinger = runBlocking {

--- a/src/test/kotlin/no/nav/syfo/domain/JournalpostIdSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/domain/JournalpostIdSpek.kt
@@ -1,0 +1,20 @@
+package no.nav.syfo.domain
+
+import org.amshove.kluent.internal.assertFailsWith
+import org.amshove.kluent.shouldNotBeNull
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+class JournalpostIdSpek : Spek({
+    describe(JournalpostId::class.java.simpleName) {
+        it("creates JournalpostId from numeric value") {
+            val journalpostId = JournalpostId("123")
+            journalpostId.shouldNotBeNull()
+        }
+        it("throws exception when value is not numeric") {
+            assertFailsWith(IllegalArgumentException::class) {
+                JournalpostId("asb")
+            }
+        }
+    }
+})


### PR DESCRIPTION
Endrer slik at `sendArbeidstakerForhandsvarsel` tar inn `journalpostId` og `varsel` i stedet for vurdering.
Det er kun `journalpostId` vi egentlig bruker fra vurderingen, resten ligger på varsel. Tenker også det gir mer mening at en slik funksjon tar inn varsel.
Da trenger vi heller ikke respository-funksjon for å hente vurdering for et varsel.
Endrer også navn på cronjob siden vi skal journalføre mer enn forhåndsvarsel.