### PR TITLE
IS-2139: Journalføre AVSLAG vurdering

### DIFF
--- a/src/main/kotlin/no/nav/syfo/domain/Vurdering.kt
+++ b/src/main/kotlin/no/nav/syfo/domain/Vurdering.kt
@@ -44,8 +44,7 @@ data class Vurdering private constructor(
     fun publish(): Vurdering = this.copy(publishedAt = nowUTC())
 
     fun shouldJournalfores(): Boolean = when (type) {
-        VurderingType.FORHANDSVARSEL, VurderingType.OPPFYLT, -> true
-        VurderingType.AVSLAG -> false
+        VurderingType.FORHANDSVARSEL, VurderingType.OPPFYLT, VurderingType.AVSLAG -> true
     }
 
     companion object {
@@ -100,18 +99,15 @@ enum class VurderingType {
 
 fun VurderingType.getDokumentTittel(): String = when (this) {
     VurderingType.FORHANDSVARSEL -> "Forhåndsvarsel om avslag på sykepenger"
-    VurderingType.OPPFYLT -> "Vurdering av §8-4 arbeidsuførhet"
-    else -> throw IllegalStateException("Should not create journalføring-pdf for type $this")
+    VurderingType.OPPFYLT, VurderingType.AVSLAG -> "Vurdering av §8-4 arbeidsuførhet"
 }
 
 fun VurderingType.getBrevkode(): BrevkodeType = when (this) {
     VurderingType.FORHANDSVARSEL -> BrevkodeType.ARBEIDSUFORHET_FORHANDSVARSEL
-    VurderingType.OPPFYLT -> BrevkodeType.ARBEIDSUFORHET_VURDERING
-    else -> throw IllegalStateException("Should not create journalføring-pdf for type $this")
+    VurderingType.OPPFYLT, VurderingType.AVSLAG -> BrevkodeType.ARBEIDSUFORHET_VURDERING
 }
 
 fun VurderingType.getJournalpostType(): JournalpostType = when (this) {
     VurderingType.FORHANDSVARSEL -> JournalpostType.UTGAAENDE
-    VurderingType.OPPFYLT -> JournalpostType.NOTAT
-    else -> throw IllegalStateException("Should not create journalføring-pdf for type $this")
+    VurderingType.OPPFYLT, VurderingType.AVSLAG -> JournalpostType.NOTAT
 }

--- a/src/main/kotlin/no/nav/syfo/infrastructure/clients/pdfgen/PdfGenClient.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/clients/pdfgen/PdfGenClient.kt
@@ -29,15 +29,15 @@ class PdfGenClient(
             pdfUrl = "$pdfGenBaseUrl$API_BASE_PATH$FORHANDSVARSEL_PATH"
         ) ?: throw RuntimeException("Failed to request pdf for forhandsvarsel, callId: $callId")
 
-    suspend fun createOppfyltPdf(
+    suspend fun createVurderingPdf(
         callId: String,
-        oppfyltPdfDTO: VurderingPdfDTO,
+        vurderingPdfDTO: VurderingPdfDTO,
     ): ByteArray =
         getPdf(
             callId = callId,
-            payload = oppfyltPdfDTO,
-            pdfUrl = "$pdfGenBaseUrl$API_BASE_PATH$OPPFYLT_PATH"
-        ) ?: throw RuntimeException("Failed to request pdf for vurdering oppfylt, callId: $callId")
+            payload = vurderingPdfDTO,
+            pdfUrl = "$pdfGenBaseUrl$API_BASE_PATH$VURDERING_PATH"
+        ) ?: throw RuntimeException("Failed to request pdf for vurdering, callId: $callId")
 
     private suspend inline fun <reified Payload> getPdf(
         callId: String,
@@ -77,7 +77,7 @@ class PdfGenClient(
     companion object {
         private const val API_BASE_PATH = "/api/v1/genpdf/isarbeidsuforhet"
         const val FORHANDSVARSEL_PATH = "/forhandsvarsel-om-avslag-pa-sykepenger"
-        const val OPPFYLT_PATH = "/vurdering-av-arbeidsuforhet"
+        const val VURDERING_PATH = "/vurdering-av-arbeidsuforhet"
 
         private val log = LoggerFactory.getLogger(PdfGenClient::class.java)
     }

--- a/src/main/kotlin/no/nav/syfo/infrastructure/clients/pdfgen/VurderingPdfService.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/clients/pdfgen/VurderingPdfService.kt
@@ -26,11 +26,10 @@ class VurderingPdfService(
                 callId = callId,
                 forhandsvarselPdfDTO = vurderingPdfDTO,
             )
-            VurderingType.OPPFYLT -> pdfGenClient.createOppfyltPdf(
+            VurderingType.OPPFYLT, VurderingType.AVSLAG -> pdfGenClient.createVurderingPdf(
                 callId = callId,
-                oppfyltPdfDTO = vurderingPdfDTO,
+                vurderingPdfDTO = vurderingPdfDTO,
             )
-            else -> throw IllegalStateException("Should not create pdf for vurdering ${vurdering.type}")
         }
     }
 }

--- a/src/test/kotlin/no/nav/syfo/UserConstants.kt
+++ b/src/test/kotlin/no/nav/syfo/UserConstants.kt
@@ -11,7 +11,7 @@ object UserConstants {
     val ARBEIDSTAKER_PERSONIDENT_PDL_FAILS = PersonIdent("11111111666")
 
     val PDF_FORHANDSVARSEL = byteArrayOf(0x2E, 0x28)
-    val PDF_OPPFYLT = byteArrayOf(0x2E, 0x30)
+    val PDF_VURDERING = byteArrayOf(0x2E, 0x30)
     const val VEILEDER_IDENT = "Z999999"
 
     const val PERSON_FORNAVN = "Fornavn"

--- a/src/test/kotlin/no/nav/syfo/api/endpoints/ArbeidsuforhetEndpointsSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/api/endpoints/ArbeidsuforhetEndpointsSpek.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.runBlocking
 import no.nav.syfo.ExternalMockEnvironment
 import no.nav.syfo.UserConstants.ARBEIDSTAKER_PERSONIDENT
 import no.nav.syfo.UserConstants.PDF_FORHANDSVARSEL
-import no.nav.syfo.UserConstants.PDF_OPPFYLT
+import no.nav.syfo.UserConstants.PDF_VURDERING
 import no.nav.syfo.UserConstants.VEILEDER_IDENT
 import no.nav.syfo.api.*
 import no.nav.syfo.api.model.ForhandsvarselRequestDTO
@@ -282,20 +282,22 @@ object ArbeidsuforhetEndpointsSpek : Spek({
                             responseDTO.veilederident shouldBeEqualTo VEILEDER_IDENT
                             responseDTO.document shouldBeEqualTo vurderingDocumentOppfylt
                             responseDTO.type shouldBeEqualTo VurderingType.OPPFYLT
+                            responseDTO.varsel shouldBeEqualTo null
 
-                            val vurdering = vurderingRepository.getVurderinger(ARBEIDSTAKER_PERSONIDENT).firstOrNull()
-                            vurdering?.begrunnelse shouldBeEqualTo begrunnelse
-                            vurdering?.personident shouldBeEqualTo ARBEIDSTAKER_PERSONIDENT
-                            vurdering?.type shouldBeEqualTo VurderingType.OPPFYLT
+                            val vurdering = vurderingRepository.getVurderinger(ARBEIDSTAKER_PERSONIDENT).single()
+                            vurdering.begrunnelse shouldBeEqualTo begrunnelse
+                            vurdering.personident shouldBeEqualTo ARBEIDSTAKER_PERSONIDENT
+                            vurdering.type shouldBeEqualTo VurderingType.OPPFYLT
+                            vurdering.varsel shouldBeEqualTo null
 
-                            val pVurderingPdf = database.getVurderingPdf(vurdering!!.uuid)
-                            pVurderingPdf?.pdf?.size shouldBeEqualTo PDF_OPPFYLT.size
-                            pVurderingPdf?.pdf?.get(0) shouldBeEqualTo PDF_OPPFYLT[0]
-                            pVurderingPdf?.pdf?.get(1) shouldBeEqualTo PDF_OPPFYLT[1]
+                            val pVurderingPdf = database.getVurderingPdf(vurdering.uuid)
+                            pVurderingPdf?.pdf?.size shouldBeEqualTo PDF_VURDERING.size
+                            pVurderingPdf?.pdf?.get(0) shouldBeEqualTo PDF_VURDERING[0]
+                            pVurderingPdf?.pdf?.get(1) shouldBeEqualTo PDF_VURDERING[1]
                         }
                     }
 
-                    it("Creates new vurdering AVSLAG and does not create PDF") {
+                    it("Creates new vurdering AVSLAG and creates PDF") {
                         val vurderingDocumentAvslag = generateDocumentComponent(
                             fritekst = begrunnelse,
                             header = "Avslag",
@@ -321,14 +323,18 @@ object ArbeidsuforhetEndpointsSpek : Spek({
                             responseDTO.veilederident shouldBeEqualTo VEILEDER_IDENT
                             responseDTO.document shouldBeEqualTo vurderingDocumentAvslag
                             responseDTO.type shouldBeEqualTo VurderingType.AVSLAG
+                            responseDTO.varsel shouldBeEqualTo null
 
-                            val vurdering = vurderingRepository.getVurderinger(ARBEIDSTAKER_PERSONIDENT).firstOrNull()
-                            vurdering?.begrunnelse shouldBeEqualTo begrunnelse
-                            vurdering?.personident shouldBeEqualTo ARBEIDSTAKER_PERSONIDENT
-                            vurdering?.type shouldBeEqualTo VurderingType.AVSLAG
+                            val vurdering = vurderingRepository.getVurderinger(ARBEIDSTAKER_PERSONIDENT).single()
+                            vurdering.begrunnelse shouldBeEqualTo begrunnelse
+                            vurdering.personident shouldBeEqualTo ARBEIDSTAKER_PERSONIDENT
+                            vurdering.type shouldBeEqualTo VurderingType.AVSLAG
+                            vurdering.varsel shouldBeEqualTo null
 
-                            val pVurderingPdf = database.getVurderingPdf(vurdering!!.uuid)
-                            pVurderingPdf shouldBeEqualTo null
+                            val pVurderingPdf = database.getVurderingPdf(vurdering.uuid)
+                            pVurderingPdf?.pdf?.size shouldBeEqualTo PDF_VURDERING.size
+                            pVurderingPdf?.pdf?.get(0) shouldBeEqualTo PDF_VURDERING[0]
+                            pVurderingPdf?.pdf?.get(1) shouldBeEqualTo PDF_VURDERING[1]
                         }
                     }
                 }

--- a/src/test/kotlin/no/nav/syfo/infrastructure/database/VarselRepositorySpek.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/database/VarselRepositorySpek.kt
@@ -82,7 +82,7 @@ class VarselRepositorySpek : Spek({
                     vurdering = vurderinger[0],
                 )
                 vurderingRepository.createVurdering(
-                    pdf = UserConstants.PDF_OPPFYLT,
+                    pdf = UserConstants.PDF_VURDERING,
                     vurdering = vurderinger[1],
                 )
 

--- a/src/test/kotlin/no/nav/syfo/infrastructure/database/VurderingRepositorySpek.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/database/VurderingRepositorySpek.kt
@@ -2,7 +2,7 @@ package no.nav.syfo.infrastructure.database
 
 import no.nav.syfo.ExternalMockEnvironment
 import no.nav.syfo.UserConstants.PDF_FORHANDSVARSEL
-import no.nav.syfo.UserConstants.PDF_OPPFYLT
+import no.nav.syfo.UserConstants.PDF_VURDERING
 import no.nav.syfo.domain.VurderingType
 import no.nav.syfo.generator.generateForhandsvarselVurdering
 import no.nav.syfo.generator.generateVurdering
@@ -61,7 +61,7 @@ class VurderingRepositorySpek : Spek({
             it("Creates vurdering OPPFYLT and pdf without varsel") {
                 vurderingRepository.createVurdering(
                     vurdering = vurderingOppfylt,
-                    pdf = PDF_OPPFYLT,
+                    pdf = PDF_VURDERING,
                 )
 
                 val vurdering = vurderingRepository.getVurderinger(vurderingOppfylt.personident).firstOrNull()
@@ -71,15 +71,15 @@ class VurderingRepositorySpek : Spek({
 
                 val pdf = database.getVurderingPdf(vurdering!!.uuid)?.pdf
                 pdf shouldNotBeEqualTo null
-                pdf?.get(0) shouldBeEqualTo PDF_OPPFYLT[0]
-                pdf?.get(1) shouldBeEqualTo PDF_OPPFYLT[1]
+                pdf?.get(0) shouldBeEqualTo PDF_VURDERING[0]
+                pdf?.get(1) shouldBeEqualTo PDF_VURDERING[1]
             }
 
-            it("Creates vurdering AVSLAG without pdf and varsel") {
+            it("Creates vurdering AVSLAG and pdf without varsel") {
                 val vurderingAvslag = generateVurdering(type = VurderingType.AVSLAG)
                 vurderingRepository.createVurdering(
-                    vurdering = vurderingAvslag.copy(type = VurderingType.AVSLAG),
-                    pdf = null,
+                    vurdering = vurderingAvslag,
+                    pdf = PDF_VURDERING,
                 )
 
                 val vurdering = vurderingRepository.getVurderinger(vurderingAvslag.personident).firstOrNull()
@@ -88,7 +88,9 @@ class VurderingRepositorySpek : Spek({
                 vurdering?.varsel shouldBeEqualTo null
 
                 val pdf = database.getVurderingPdf(vurdering!!.uuid)?.pdf
-                pdf shouldBeEqualTo null
+                pdf shouldNotBeEqualTo null
+                pdf?.get(0) shouldBeEqualTo PDF_VURDERING[0]
+                pdf?.get(1) shouldBeEqualTo PDF_VURDERING[1]
             }
         }
     }

--- a/src/test/kotlin/no/nav/syfo/infrastructure/journalforing/JournalforingServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/journalforing/JournalforingServiceSpek.kt
@@ -8,18 +8,16 @@ import kotlinx.coroutines.runBlocking
 import no.nav.syfo.ExternalMockEnvironment
 import no.nav.syfo.UserConstants.ARBEIDSTAKER_PERSONIDENT
 import no.nav.syfo.UserConstants.PDF_FORHANDSVARSEL
-import no.nav.syfo.UserConstants.PDF_OPPFYLT
+import no.nav.syfo.UserConstants.PDF_VURDERING
 import no.nav.syfo.domain.VurderingType
-import no.nav.syfo.domain.getBrevkode
-import no.nav.syfo.domain.getDokumentTittel
-import no.nav.syfo.domain.getJournalpostType
 import no.nav.syfo.generator.generateForhandsvarselVurdering
 import no.nav.syfo.generator.generateJournalpostRequest
 import no.nav.syfo.generator.generateVurdering
 import no.nav.syfo.infrastructure.clients.dokarkiv.DokarkivClient
+import no.nav.syfo.infrastructure.clients.dokarkiv.dto.BrevkodeType
+import no.nav.syfo.infrastructure.clients.dokarkiv.dto.JournalpostType
 import no.nav.syfo.infrastructure.mock.dokarkivResponse
 import no.nav.syfo.infrastructure.mock.mockedJournalpostId
-import org.amshove.kluent.internal.assertFailsWith
 import org.amshove.kluent.shouldBeEqualTo
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -45,64 +43,74 @@ object JournalforingServiceSpek : Spek({
 
         describe("Journalføring") {
             it("Journalfører OPPFYLT vurdering") {
-                runBlocking {
-                    val journalpostId = journalforingService.journalfor(
+                val journalpostId = runBlocking {
+                    journalforingService.journalfor(
                         personident = ARBEIDSTAKER_PERSONIDENT,
-                        pdf = PDF_OPPFYLT,
+                        pdf = PDF_VURDERING,
                         vurdering = vurderingOppfylt,
                     )
+                }
 
-                    journalpostId shouldBeEqualTo mockedJournalpostId
+                journalpostId shouldBeEqualTo mockedJournalpostId
 
-                    coVerify(exactly = 1) {
-                        dokarkivMock.journalfor(
-                            journalpostRequest = generateJournalpostRequest(
-                                tittel = VurderingType.OPPFYLT.getDokumentTittel(),
-                                brevkodeType = VurderingType.OPPFYLT.getBrevkode(),
-                                pdf = PDF_OPPFYLT,
-                                vurderingUuid = vurderingOppfylt.uuid,
-                                journalpostType = VurderingType.OPPFYLT.getJournalpostType().name,
-                            )
+                coVerify(exactly = 1) {
+                    dokarkivMock.journalfor(
+                        journalpostRequest = generateJournalpostRequest(
+                            tittel = "Vurdering av §8-4 arbeidsuførhet",
+                            brevkodeType = BrevkodeType.ARBEIDSUFORHET_VURDERING,
+                            pdf = PDF_VURDERING,
+                            vurderingUuid = vurderingOppfylt.uuid,
+                            journalpostType = JournalpostType.NOTAT.name,
                         )
-                    }
+                    )
                 }
             }
 
             it("Journalfører FORHANDSVARSEL vurdering") {
-                runBlocking {
-                    val journalpostId = journalforingService.journalfor(
+                val journalpostId = runBlocking {
+                    journalforingService.journalfor(
                         personident = ARBEIDSTAKER_PERSONIDENT,
                         pdf = PDF_FORHANDSVARSEL,
                         vurdering = vurderingForhandsvarsel,
                     )
+                }
 
-                    journalpostId shouldBeEqualTo mockedJournalpostId
+                journalpostId shouldBeEqualTo mockedJournalpostId
 
-                    coVerify(exactly = 1) {
-                        dokarkivMock.journalfor(
-                            journalpostRequest = generateJournalpostRequest(
-                                tittel = VurderingType.FORHANDSVARSEL.getDokumentTittel(),
-                                brevkodeType = VurderingType.FORHANDSVARSEL.getBrevkode(),
-                                pdf = PDF_FORHANDSVARSEL,
-                                vurderingUuid = vurderingForhandsvarsel.uuid,
-                                journalpostType = VurderingType.FORHANDSVARSEL.getJournalpostType().name,
-                            )
+                coVerify(exactly = 1) {
+                    dokarkivMock.journalfor(
+                        journalpostRequest = generateJournalpostRequest(
+                            tittel = "Forhåndsvarsel om avslag på sykepenger",
+                            brevkodeType = BrevkodeType.ARBEIDSUFORHET_FORHANDSVARSEL,
+                            pdf = PDF_FORHANDSVARSEL,
+                            vurderingUuid = vurderingForhandsvarsel.uuid,
+                            journalpostType = JournalpostType.UTGAAENDE.name,
                         )
-                    }
+                    )
                 }
             }
 
-            it("Journalfører ikke når AVSLAG vurdering") {
-                runBlocking {
-                    assertFailsWith<IllegalStateException> {
-                        journalforingService.journalfor(
-                            personident = ARBEIDSTAKER_PERSONIDENT,
-                            pdf = byteArrayOf(0x2E, 0x21),
-                            vurdering = vurderingAvslag,
-                        )
-                    }
+            it("Journalfører AVSLAG vurdering") {
+                val journalpostId = runBlocking {
+                    journalforingService.journalfor(
+                        personident = ARBEIDSTAKER_PERSONIDENT,
+                        pdf = PDF_VURDERING,
+                        vurdering = vurderingAvslag,
+                    )
+                }
 
-                    coVerify(exactly = 0) { dokarkivMock.journalfor(any()) }
+                journalpostId shouldBeEqualTo mockedJournalpostId
+
+                coVerify(exactly = 1) {
+                    dokarkivMock.journalfor(
+                        journalpostRequest = generateJournalpostRequest(
+                            tittel = "Vurdering av §8-4 arbeidsuførhet",
+                            brevkodeType = BrevkodeType.ARBEIDSUFORHET_VURDERING,
+                            pdf = PDF_VURDERING,
+                            vurderingUuid = vurderingAvslag.uuid,
+                            journalpostType = JournalpostType.NOTAT.name,
+                        )
+                    )
                 }
             }
         }

--- a/src/test/kotlin/no/nav/syfo/infrastructure/mock/PdfGenClientMock.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/mock/PdfGenClientMock.kt
@@ -12,8 +12,8 @@ fun MockRequestHandleScope.pdfGenClientMockResponse(request: HttpRequestData): H
         requestUrl.endsWith(PdfGenClient.Companion.FORHANDSVARSEL_PATH) -> {
             respond(content = UserConstants.PDF_FORHANDSVARSEL)
         }
-        requestUrl.endsWith(PdfGenClient.Companion.OPPFYLT_PATH) -> {
-            respond(content = UserConstants.PDF_OPPFYLT)
+        requestUrl.endsWith(PdfGenClient.Companion.VURDERING_PATH) -> {
+            respond(content = UserConstants.PDF_VURDERING)
         }
 
         else -> error("Unhandled pdf ${request.url.encodedPath}")


### PR DESCRIPTION
Etter litt diskusjon med Ingrid landet vi på at både OPPFYLG og AVSLAG skal journalføres, men ikke varsles eller vises til innbygger. Se https://nav-it.slack.com/archives/C06HMAY0ELA/p1710242102119539?thread_ts=1709560585.048279&cid=C06HMAY0ELA