### PR TITLE
IS-2268: Implement Vurdering sealed interface

### DIFF
--- a/src/main/kotlin/no/nav/syfo/api/endpoints/ArbeidsuforhetEndpoints.kt
+++ b/src/main/kotlin/no/nav/syfo/api/endpoints/ArbeidsuforhetEndpoints.kt
@@ -8,6 +8,7 @@ import io.ktor.server.routing.*
 import no.nav.syfo.api.model.VurderingRequestDTO
 import no.nav.syfo.api.model.VurderingResponseDTO
 import no.nav.syfo.application.service.VurderingService
+import no.nav.syfo.domain.Vurdering
 import no.nav.syfo.domain.VurderingType
 import no.nav.syfo.infrastructure.NAV_PERSONIDENT_HEADER
 import no.nav.syfo.infrastructure.clients.veiledertilgang.VeilederTilgangskontrollClient
@@ -55,7 +56,7 @@ fun Route.registerArbeidsuforhetEndpoints(
             val callId = call.getCallId()
 
             val existingVurderinger = vurderingService.getVurderinger(personIdent)
-            if (existingVurderinger.firstOrNull()?.isForhandsvarsel() == true &&
+            if (existingVurderinger.firstOrNull() is Vurdering.Forhandsvarsel &&
                 requestDTO.type == VurderingType.FORHANDSVARSEL
             ) {
                 throw IllegalArgumentException("Duplicate ${VurderingType.FORHANDSVARSEL} for given person")

--- a/src/main/kotlin/no/nav/syfo/application/service/VurderingService.kt
+++ b/src/main/kotlin/no/nav/syfo/application/service/VurderingService.kt
@@ -29,14 +29,28 @@ class VurderingService(
         gjelderFom: LocalDate?,
         callId: String,
     ): Vurdering {
-        val vurdering = Vurdering(
-            personident = personident,
-            veilederident = veilederident,
-            begrunnelse = begrunnelse,
-            document = document,
-            type = type,
-            gjelderFom = gjelderFom,
-        )
+        val vurdering = when (type) {
+            VurderingType.FORHANDSVARSEL -> Vurdering.Forhandsvarsel(
+                personident = personident,
+                veilederident = veilederident,
+                begrunnelse = begrunnelse,
+                document = document,
+            )
+            VurderingType.OPPFYLT -> Vurdering.Oppfylt(
+                personident = personident,
+                veilederident = veilederident,
+                begrunnelse = begrunnelse,
+                document = document,
+            )
+            VurderingType.AVSLAG -> Vurdering.Avslag(
+                personident = personident,
+                veilederident = veilederident,
+                begrunnelse = begrunnelse,
+                document = document,
+                gjelderFom = gjelderFom ?: throw IllegalArgumentException("gjelderFom is required for $type")
+            )
+        }
+
         val pdf = if (vurdering.shouldJournalfores()) {
             vurderingPdfService.createVurderingPdf(
                 vurdering = vurdering,

--- a/src/main/kotlin/no/nav/syfo/application/service/VurderingService.kt
+++ b/src/main/kotlin/no/nav/syfo/application/service/VurderingService.kt
@@ -47,7 +47,7 @@ class VurderingService(
                 veilederident = veilederident,
                 begrunnelse = begrunnelse,
                 document = document,
-                gjelderFom = gjelderFom ?: throw IllegalArgumentException("gjelderFom is required for $type")
+                gjelderFom = gjelderFom ?: LocalDate.now() // TODO: throw IllegalArgumentException("gjelderFom is required for $type") når frontend er klar
             )
         }
 

--- a/src/main/kotlin/no/nav/syfo/domain/Vurdering.kt
+++ b/src/main/kotlin/no/nav/syfo/domain/Vurdering.kt
@@ -20,8 +20,18 @@ sealed interface Vurdering {
     val publishedAt: OffsetDateTime?
     val gjelderFom: LocalDate?
 
-    fun journalfor(journalpostId: JournalpostId): Vurdering
-    fun publish(): Vurdering
+    fun journalfor(journalpostId: JournalpostId): Vurdering = when (this) {
+        is Forhandsvarsel -> this.copy(journalpostId = journalpostId)
+        is Oppfylt -> this.copy(journalpostId = journalpostId)
+        is Avslag -> this.copy(journalpostId = journalpostId)
+    }
+
+    fun publish(): Vurdering = when (this) {
+        is Forhandsvarsel -> this.copy(publishedAt = nowUTC())
+        is Oppfylt -> this.copy(publishedAt = nowUTC())
+        is Avslag -> this.copy(publishedAt = nowUTC())
+    }
+
     fun shouldJournalfores(): Boolean = true
 
     data class Forhandsvarsel internal constructor(
@@ -51,9 +61,6 @@ sealed interface Vurdering {
             journalpostId = null,
             publishedAt = null,
         )
-
-        override fun journalfor(journalpostId: JournalpostId): Vurdering = this.copy(journalpostId = journalpostId)
-        override fun publish(): Vurdering = this.copy(publishedAt = nowUTC())
     }
 
     data class Oppfylt internal constructor(
@@ -83,9 +90,6 @@ sealed interface Vurdering {
             journalpostId = null,
             publishedAt = null,
         )
-
-        override fun journalfor(journalpostId: JournalpostId): Vurdering = this.copy(journalpostId = journalpostId)
-        override fun publish(): Vurdering = this.copy(publishedAt = nowUTC())
     }
 
     data class Avslag internal constructor(
@@ -118,8 +122,6 @@ sealed interface Vurdering {
             publishedAt = null,
         )
 
-        override fun journalfor(journalpostId: JournalpostId): Vurdering = this.copy(journalpostId = journalpostId)
-        override fun publish(): Vurdering = this.copy(publishedAt = nowUTC())
         override fun shouldJournalfores(): Boolean = false
     }
 

--- a/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/VurderingRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/VurderingRepository.kt
@@ -51,9 +51,7 @@ class VurderingRepository(private val database: DatabaseInterface) : IVurderingR
                     pdf = pdf,
                 )
             }
-            if (vurdering.isForhandsvarsel()) {
-                if (vurdering.varsel == null)
-                    throw IllegalStateException("Vurdering should have Varsel when creating forhåndsvarsel")
+            if (vurdering is Vurdering.Forhandsvarsel) {
                 connection.createVarsel(
                     vurderingId = pVurdering.id,
                     varsel = vurdering.varsel,
@@ -92,7 +90,14 @@ class VurderingRepository(private val database: DatabaseInterface) : IVurderingR
                             getBytes("pdf"),
                         )
                     }
-            }.map { (pVurdering, pdf) -> Pair(pVurdering.toVurdering(null), pdf) }
+            }.map { (pVurdering, pdf) ->
+                Pair(
+                    pVurdering.toVurdering(
+                        varsel = connection.getVarselForVurdering(pVurdering)
+                    ),
+                    pdf
+                )
+            }
         }
 
     private fun Connection.createVurdering(

--- a/src/test/kotlin/no/nav/syfo/application/service/VarselServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/application/service/VarselServiceSpek.kt
@@ -73,7 +73,7 @@ class VarselServiceSpek : Spek({
                 pdf = UserConstants.PDF_FORHANDSVARSEL,
                 vurdering = vurderingForhandsvarsel,
             )
-            val unpublishedVarsel = vurderingForhandsvarsel.varsel!!
+            val unpublishedVarsel = vurderingForhandsvarsel.varsel
             vurderingRepository.update(vurderingForhandsvarsel.copy(journalpostId = journalpostId))
 
             return unpublishedVarsel
@@ -92,7 +92,7 @@ class VarselServiceSpek : Spek({
                 pdf = UserConstants.PDF_FORHANDSVARSEL,
                 vurdering = vurderingWithExpiredVarsel
             )
-            val publishedVarsel = vurderingWithExpiredVarsel.varsel!!.copy(publishedAt = publishedAt)
+            val publishedVarsel = vurderingWithExpiredVarsel.varsel.copy(publishedAt = publishedAt)
             varselRepository.update(publishedVarsel)
             return publishedVarsel
         }

--- a/src/test/kotlin/no/nav/syfo/generator/VurderingGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/generator/VurderingGenerator.kt
@@ -2,6 +2,7 @@ package no.nav.syfo.generator
 
 import no.nav.syfo.UserConstants
 import no.nav.syfo.domain.*
+import java.time.LocalDate
 
 fun generateForhandsvarselVurdering(
     personident: PersonIdent = UserConstants.ARBEIDSTAKER_PERSONIDENT,
@@ -12,17 +13,32 @@ fun generateForhandsvarselVurdering(
     begrunnelse = begrunnelse,
     document = document,
     type = VurderingType.FORHANDSVARSEL,
-)
+) as Vurdering.Forhandsvarsel
 
 fun generateVurdering(
     personident: PersonIdent = UserConstants.ARBEIDSTAKER_PERSONIDENT,
     begrunnelse: String = "En begrunnelse",
     document: List<DocumentComponent> = generateDocumentComponent(begrunnelse),
     type: VurderingType,
-) = Vurdering(
-    personident = personident,
-    veilederident = UserConstants.VEILEDER_IDENT,
-    begrunnelse = begrunnelse,
-    document = document,
-    type = type,
-)
+) = when (type) {
+    VurderingType.FORHANDSVARSEL -> Vurdering.Forhandsvarsel(
+        personident = personident,
+        veilederident = UserConstants.VEILEDER_IDENT,
+        begrunnelse = begrunnelse,
+        document = document,
+    )
+
+    VurderingType.OPPFYLT -> Vurdering.Oppfylt(
+        personident = personident,
+        veilederident = UserConstants.VEILEDER_IDENT,
+        begrunnelse = begrunnelse,
+        document = document,
+    )
+    VurderingType.AVSLAG -> Vurdering.Avslag(
+        personident = personident,
+        veilederident = UserConstants.VEILEDER_IDENT,
+        begrunnelse = begrunnelse,
+        document = document,
+        gjelderFom = LocalDate.now(),
+    )
+}

--- a/src/test/kotlin/no/nav/syfo/infrastructure/database/VarselRepositorySpek.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/database/VarselRepositorySpek.kt
@@ -46,7 +46,7 @@ class VarselRepositorySpek : Spek({
                         pdf = UserConstants.PDF_FORHANDSVARSEL,
                         vurdering = it,
                     )
-                    varselRepository.update(it.varsel!!.copy(publishedAt = OffsetDateTime.now().minusWeeks(1)))
+                    varselRepository.update(it.varsel.copy(publishedAt = OffsetDateTime.now().minusWeeks(1)))
                 }
 
                 val retrievedExpiredVarsler = varselRepository.getUnpublishedExpiredVarsler()
@@ -65,7 +65,7 @@ class VarselRepositorySpek : Spek({
                         pdf = UserConstants.PDF_FORHANDSVARSEL,
                         vurdering = it,
                     )
-                    varselRepository.update(it.varsel!!.copy(publishedAt = OffsetDateTime.now().minusWeeks(1)))
+                    varselRepository.update(it.varsel.copy(publishedAt = OffsetDateTime.now().minusWeeks(1)))
                 }
 
                 val retrievedUnpublishedExpiredVarsler = varselRepository.getUnpublishedExpiredVarsler()

--- a/src/test/kotlin/no/nav/syfo/infrastructure/database/VurderingRepositorySpek.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/database/VurderingRepositorySpek.kt
@@ -7,7 +7,6 @@ import no.nav.syfo.domain.VurderingType
 import no.nav.syfo.generator.generateForhandsvarselVurdering
 import no.nav.syfo.generator.generateVurdering
 import no.nav.syfo.infrastructure.database.repository.VurderingRepository
-import org.amshove.kluent.internal.assertFailsWith
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldNotBeEqualTo
 import org.spekframework.spek2.Spek
@@ -35,23 +34,12 @@ class VurderingRepositorySpek : Spek({
                 val vurdering = vurderingRepository.getVurderinger(vurderingForhandsvarsel.personident).firstOrNull()
                 vurdering?.type shouldBeEqualTo VurderingType.FORHANDSVARSEL
                 vurdering?.journalpostId shouldBeEqualTo null
-                vurdering?.varsel?.uuid shouldBeEqualTo vurderingForhandsvarsel.varsel?.uuid
+                vurdering?.varsel?.uuid shouldBeEqualTo vurderingForhandsvarsel.varsel.uuid
 
                 val pdf = database.getVurderingPdf(vurdering!!.uuid)?.pdf
                 pdf shouldNotBeEqualTo null
                 pdf?.get(0) shouldBeEqualTo PDF_FORHANDSVARSEL[0]
                 pdf?.get(1) shouldBeEqualTo PDF_FORHANDSVARSEL[1]
-            }
-
-            it("fails if vurdering is missing a varsel") {
-                val vurderingWithoutVarsel = vurderingForhandsvarsel.copy(varsel = null)
-
-                assertFailsWith(IllegalStateException::class) {
-                    vurderingRepository.createVurdering(
-                        pdf = PDF_FORHANDSVARSEL,
-                        vurdering = vurderingWithoutVarsel,
-                    )
-                }
             }
         }
 


### PR DESCRIPTION
For å bl.a. sørge for at Forhåndsvarsel-vurdering skal ha `varsel` og bare Avslag kan ha `gjelderFom`.