### PR TITLE
IS-2268: Set gjelder_fom = created_at for avslag

### DIFF
--- a/src/main/resources/db/migration/V1_6__update_vurdering_gjelder_fom.sql
+++ b/src/main/resources/db/migration/V1_6__update_vurdering_gjelder_fom.sql
@@ -1,0 +1,1 @@
+UPDATE VURDERING SET gjelder_fom = created_at WHERE type = 'AVSLAG';


### PR DESCRIPTION
Vi har ingen avslag-vurderinger i prod så dette er kun for at vi ikke skal få feil i dev når vi laster avslag-vurderinger som mangler gjelder_fom (https://github.com/navikt/isarbeidsuforhet/blob/main/src/main/kotlin/no/nav/syfo/domain/Vurdering.kt#L174)