### PR TITLE
IS-2350: Add separate update-functions for journalforing and published_at

### DIFF
--- a/src/main/kotlin/no/nav/syfo/application/IVurderingRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/application/IVurderingRepository.kt
@@ -15,7 +15,9 @@ interface IVurderingRepository {
         pdf: ByteArray,
     ): Vurdering
 
-    fun update(vurdering: Vurdering)
+    fun setPublished(vurdering: Vurdering)
+
+    fun setJournalpostId(vurdering: Vurdering)
 
     fun getNotJournalforteVurderinger(): List<Pair<Vurdering, ByteArray>>
 }

--- a/src/main/kotlin/no/nav/syfo/application/service/VurderingService.kt
+++ b/src/main/kotlin/no/nav/syfo/application/service/VurderingService.kt
@@ -91,7 +91,7 @@ class VurderingService(
                 val journalfortVurdering = vurdering.journalfor(
                     journalpostId = JournalpostId(journalpostId.toString()),
                 )
-                vurderingRepository.update(journalfortVurdering)
+                vurderingRepository.setJournalpostId(journalfortVurdering)
 
                 journalfortVurdering
             }
@@ -104,7 +104,7 @@ class VurderingService(
             val producerResult = vurderingProducer.send(vurdering = vurdering)
             producerResult.map {
                 val publishedVurdering = it.publish()
-                vurderingRepository.update(publishedVurdering)
+                vurderingRepository.setPublished(publishedVurdering)
                 publishedVurdering
             }
         }

--- a/src/test/kotlin/no/nav/syfo/application/service/VarselServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/application/service/VarselServiceSpek.kt
@@ -74,7 +74,7 @@ class VarselServiceSpek : Spek({
                 vurdering = vurderingForhandsvarsel,
             )
             val unpublishedVarsel = vurderingForhandsvarsel.varsel
-            vurderingRepository.update(vurderingForhandsvarsel.copy(journalpostId = journalpostId))
+            vurderingRepository.setJournalpostId(vurderingForhandsvarsel.copy(journalpostId = journalpostId))
 
             return unpublishedVarsel
         }

--- a/src/test/kotlin/no/nav/syfo/application/service/VurderingServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/application/service/VurderingServiceSpek.kt
@@ -184,7 +184,7 @@ class VurderingServiceSpek : Spek({
                     vurdering = vurderingForhandsvarsel,
                 )
                 val journalfortVarsel = vurderingForhandsvarsel.journalfor(journalpostId = JournalpostId(mockedJournalpostId.toString()))
-                vurderingRepository.update(journalfortVarsel)
+                vurderingRepository.setJournalpostId(journalfortVarsel)
 
                 val journalforteVurderinger = runBlocking {
                     vurderingService.journalforVurderinger()


### PR DESCRIPTION
Vi hadde en bug her som overskrev `journalpost_id` eller `published_at` når cronjobbene for å oppdatere disse skjedde på samme tid. Tilbakemeldingen fra datavarehus var at ting kom dobbelt på kafka, men det er jo mye mulig at noe har blitt journalført dobbelt også (men med ulike journalpostIDer).