### PR TITLE
IS-2271: Add isFinal values for VurderingType

### DIFF
--- a/.nais/kafka/arbeidsuforhet-vurdering.yaml
+++ b/.nais/kafka/arbeidsuforhet-vurdering.yaml
@@ -25,6 +25,9 @@ spec:
     - team: teamsykefravr
       application: ispersonoppgave
       access: read
+    - team: teamsykefravr
+      application: syfooversiktsrv
+      access: read
     - team: disykefravar
       application: dvh-sykefravar-airflow-kafka
       access: read

--- a/src/main/kotlin/no/nav/syfo/domain/Vurdering.kt
+++ b/src/main/kotlin/no/nav/syfo/domain/Vurdering.kt
@@ -177,8 +177,8 @@ sealed interface Vurdering {
     }
 }
 
-enum class VurderingType {
-    FORHANDSVARSEL, OPPFYLT, AVSLAG
+enum class VurderingType(val isFinal: Boolean) {
+    FORHANDSVARSEL(false), OPPFYLT(true), AVSLAG(true);
 }
 
 fun VurderingType.getDokumentTittel(): String = when (this) {

--- a/src/main/kotlin/no/nav/syfo/infrastructure/kafka/VurderingProducer.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/kafka/VurderingProducer.kt
@@ -42,6 +42,7 @@ data class VurderingRecord(
     val type: VurderingType,
     val begrunnelse: String,
     val gjelderFom: LocalDate?,
+    val isFinalVurdering: Boolean,
 ) {
     companion object {
         fun fromVurdering(vurdering: Vurdering): VurderingRecord =
@@ -53,6 +54,7 @@ data class VurderingRecord(
                 type = vurdering.type,
                 begrunnelse = vurdering.begrunnelse,
                 gjelderFom = vurdering.gjelderFom,
+                isFinalVurdering = vurdering.type.isFinal
             )
     }
 }


### PR DESCRIPTION
Legger til boolsk `isFinalVurdering ` slik at konsument i `syfooversiktsrv` kan vite om vurderingen er endelig og at derfor arbeidsuforhet ikke lenger er relevant å vise for denne personen i oversikten.

- [x] Testet at `ispersonoppgave` klarer å konsumere endringen i recorden.

- Se [tilhørende PR i syfooversiktsrv](https://github.com/navikt/syfooversiktsrv/pull/364)