### PR TITLE
IS-2271: Add syfooversiktsrv to inbound accesspolicy

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -41,6 +41,7 @@ spec:
     inbound:
       rules:
         - application: syfomodiaperson
+        - application: syfooversiktsrv
     outbound:
       external:
         - host: "login.microsoftonline.com"

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -41,6 +41,7 @@ spec:
     inbound:
       rules:
         - application: syfomodiaperson
+        - application: syfooversiktsrv
     outbound:
       external:
         - host: "login.microsoftonline.com"


### PR DESCRIPTION
Legger til `syfooversiktsrv` til inbound access policy.

[Se relatert PR i syfooversiktsrv](https://github.com/navikt/syfooversiktsrv/pull/367)