### PR TITLE
Use personident-based record key to ensure order

### DIFF
--- a/src/main/kotlin/no/nav/syfo/domain/PersonIdent.kt
+++ b/src/main/kotlin/no/nav/syfo/domain/PersonIdent.kt
@@ -1,5 +1,7 @@
 package no.nav.syfo.domain
 
+import java.util.*
+
 data class PersonIdent(val value: String) {
     private val elevenDigits = Regex("^\\d{11}\$")
 
@@ -9,3 +11,5 @@ data class PersonIdent(val value: String) {
         }
     }
 }
+
+fun PersonIdent.asProducerRecordKey(): String = UUID.nameUUIDFromBytes(value.toByteArray()).toString()

--- a/src/main/kotlin/no/nav/syfo/infrastructure/kafka/ExpiredForhandsvarselProducer.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/kafka/ExpiredForhandsvarselProducer.kt
@@ -3,6 +3,7 @@ package no.nav.syfo.infrastructure.kafka
 import no.nav.syfo.application.IExpiredForhandsvarselProducer
 import no.nav.syfo.domain.PersonIdent
 import no.nav.syfo.domain.Varsel
+import no.nav.syfo.domain.asProducerRecordKey
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.slf4j.LoggerFactory
@@ -18,7 +19,7 @@ class ExpiredForhandsvarselProducer(private val producer: KafkaProducer<String, 
             producer.send(
                 ProducerRecord(
                     TOPIC,
-                    UUID.randomUUID().toString(),
+                    personIdent.asProducerRecordKey(),
                     ExpiredForhandsvarselRecord.fromVarsel(personIdent, varsel),
                 )
             ).get()

--- a/src/main/kotlin/no/nav/syfo/infrastructure/kafka/VurderingProducer.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/kafka/VurderingProducer.kt
@@ -3,6 +3,7 @@ package no.nav.syfo.infrastructure.kafka
 import no.nav.syfo.application.IVurderingProducer
 import no.nav.syfo.domain.Vurdering
 import no.nav.syfo.domain.VurderingType
+import no.nav.syfo.domain.asProducerRecordKey
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.slf4j.LoggerFactory
@@ -18,7 +19,7 @@ class VurderingProducer(private val producer: KafkaProducer<String, VurderingRec
             producer.send(
                 ProducerRecord(
                     TOPIC,
-                    UUID.randomUUID().toString(),
+                    vurdering.personident.asProducerRecordKey(),
                     VurderingRecord.fromVurdering(vurdering),
                 )
             ).get()


### PR DESCRIPTION
Kafka garanterer rekkefølgen innad i en partisjon og records med samme key vil havne på samme partisjon