### PR TITLE
IS-2824: Delete wrong forhandsvarsel

### DIFF
--- a/src/main/resources/db/migration/V2_1__delete_wrong_varsel.sql
+++ b/src/main/resources/db/migration/V2_1__delete_wrong_varsel.sql
@@ -1,0 +1,1 @@
+DELETE FROM vurdering WHERE uuid = '8292a37b-f308-44ba-a6f3-450018754070';


### PR DESCRIPTION
Sletter feilaktig sendt forhåndsvarsel
Ses i sammenheng med [denne](https://github.com/navikt/syfooversiktsrv/compare/IS-2824-delete-wrong-arbeidsuforhet-vurdering-set-to-inactive?expand=1)