### PR TITLE
IS-3096: Handle identhendelser

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 group = "no.nav.syfo"
 version = "0.0.1"
 
+val CONFLUENT = "7.8.0"
 val FLYWAY = "11.3.0"
 val HIKARI = "6.2.1"
 val POSTGRES = "42.7.5"
@@ -70,6 +71,22 @@ dependencies {
 
     // (De-)serialization
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$JACKSON_DATATYPE")
+
+    implementation("io.confluent:kafka-avro-serializer:$CONFLUENT", excludeLog4j)
+    constraints {
+        implementation("org.apache.avro:avro") {
+            because("io.confluent:kafka-avro-serializer:$CONFLUENT -> https://www.cve.org/CVERecord?id=CVE-2023-39410")
+            version {
+                require("1.12.0")
+            }
+        }
+        implementation("org.apache.commons:commons-compress") {
+            because("org.apache.commons:commons-compress:1.22 -> https://www.cve.org/CVERecord?id=CVE-2012-2098")
+            version {
+                require("1.27.1")
+            }
+        }
+    }
 
     // Tests
     testImplementation("io.ktor:ktor-server-test-host:$KTOR")

--- a/src/main/kotlin/no/nav/syfo/App.kt
+++ b/src/main/kotlin/no/nav/syfo/App.kt
@@ -24,6 +24,9 @@ import no.nav.syfo.infrastructure.clients.pdl.PdlClient
 import no.nav.syfo.infrastructure.clients.veiledertilgang.VeilederTilgangskontrollClient
 import no.nav.syfo.infrastructure.clients.wellknown.getWellKnown
 import no.nav.syfo.infrastructure.kafka.*
+import no.nav.syfo.infrastructure.kafka.identhendelse.IdenthendelseConsumer
+import no.nav.syfo.infrastructure.kafka.identhendelse.IdenthendelseService
+import no.nav.syfo.infrastructure.kafka.identhendelse.launchIdenthendelseConsumer
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.slf4j.LoggerFactory
 import java.util.concurrent.TimeUnit
@@ -139,6 +142,15 @@ fun main() {
                     environment = environment,
                     vurderingService = vurderingService,
                     varselService = varselService,
+                )
+                launchIdenthendelseConsumer(
+                    applicationState = applicationState,
+                    kafkaEnvironment = environment.kafka,
+                    identhendelseConsumer = IdenthendelseConsumer(
+                        identhendelseService = IdenthendelseService(
+                            vurderingRepository = vurderingRepository,
+                        )
+                    )
                 )
             }
         }

--- a/src/main/kotlin/no/nav/syfo/ApplicationEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/ApplicationEnvironment.kt
@@ -23,6 +23,9 @@ data class Environment(
         aivenKeystoreLocation = getEnvVar("KAFKA_KEYSTORE_PATH"),
         aivenSecurityProtocol = "SSL",
         aivenTruststoreLocation = getEnvVar("KAFKA_TRUSTSTORE_PATH"),
+        aivenSchemaRegistryUrl = getEnvVar("KAFKA_SCHEMA_REGISTRY"),
+        aivenRegistryUser = getEnvVar("KAFKA_SCHEMA_REGISTRY_USER"),
+        aivenRegistryPassword = getEnvVar("KAFKA_SCHEMA_REGISTRY_PASSWORD"),
     ),
     val azure: AzureEnvironment =
         AzureEnvironment(

--- a/src/main/kotlin/no/nav/syfo/application/IVurderingRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/application/IVurderingRepository.kt
@@ -24,4 +24,6 @@ interface IVurderingRepository {
     fun setJournalpostId(vurdering: Vurdering)
 
     fun getNotJournalforteVurderinger(): List<Pair<Vurdering, ByteArray>>
+
+    fun updatePersonident(nyPersonident: PersonIdent, vurderinger: List<Vurdering>)
 }

--- a/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/VurderingRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/VurderingRepository.kt
@@ -137,6 +137,20 @@ class VurderingRepository(private val database: DatabaseInterface) : IVurderingR
             }
         }
 
+    override fun updatePersonident(nyPersonident: PersonIdent, vurderinger: List<Vurdering>) = database.connection.use { connection ->
+        connection.prepareStatement(UPDATE_PERSONIDENT).use {
+            vurderinger.forEach { vurdering ->
+                it.setString(1, nyPersonident.value)
+                it.setString(2, vurdering.uuid.toString())
+                val updated = it.executeUpdate()
+                if (updated != 1) {
+                    throw SQLException("Expected a single row to be updated, got update count $updated")
+                }
+            }
+        }
+        connection.commit()
+    }
+
     private fun Connection.createVurdering(
         vurdering: Vurdering,
     ): PVurdering {
@@ -245,6 +259,11 @@ class VurderingRepository(private val database: DatabaseInterface) : IVurderingR
         private const val UPDATE_PUBLISHED_AT =
             """
                 UPDATE VURDERING SET updated_at=?, published_at=? WHERE uuid=?
+            """
+
+        private const val UPDATE_PERSONIDENT =
+            """
+                UPDATE VURDERING SET personident=? WHERE uuid=?
             """
 
         private const val CREATE_VARSEL =

--- a/src/main/kotlin/no/nav/syfo/infrastructure/kafka/KafkaConfig.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/kafka/KafkaConfig.kt
@@ -1,9 +1,11 @@
 package no.nav.syfo.infrastructure.kafka
 
 import org.apache.kafka.clients.CommonClientConfigs
+import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.producer.ProducerConfig
 import org.apache.kafka.common.config.SaslConfigs
 import org.apache.kafka.common.config.SslConfigs
+import org.apache.kafka.common.serialization.StringDeserializer
 import org.apache.kafka.common.serialization.StringSerializer
 import java.util.*
 
@@ -19,6 +21,22 @@ inline fun <reified Serializer> kafkaAivenProducerConfig(
         this[ProducerConfig.RETRIES_CONFIG] = "100000"
         this[ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG] = StringSerializer::class.java.canonicalName
         this[ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG] = Serializer::class.java.canonicalName
+    }
+}
+
+inline fun <reified Deserializer> kafkaAivenConsumerConfig(
+    kafkaEnvironment: KafkaEnvironment,
+): Properties {
+    return Properties().apply {
+        putAll(commonKafkaAivenConfig(kafkaEnvironment))
+
+        this[ConsumerConfig.GROUP_ID_CONFIG] = "isarbeidsuforhet-v1"
+        this[ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG] = StringDeserializer::class.java.canonicalName
+        this[ConsumerConfig.AUTO_OFFSET_RESET_CONFIG] = "earliest"
+        this[ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG] = "false" // we commit manually if db persistence is successful
+        this[ConsumerConfig.MAX_POLL_RECORDS_CONFIG] = "1000"
+        this[ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG] = "" + (10 * 1024 * 1024)
+        this[ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG] = Deserializer::class.java.canonicalName
     }
 }
 

--- a/src/main/kotlin/no/nav/syfo/infrastructure/kafka/KafkaConsumerService.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/kafka/KafkaConsumerService.kt
@@ -1,0 +1,10 @@
+package no.nav.syfo.infrastructure.kafka
+
+import org.apache.kafka.clients.consumer.KafkaConsumer
+
+interface KafkaConsumerService<ConsumerRecordValue> {
+    val pollDurationInMillis: Long
+    suspend fun pollAndProcessRecords(
+        kafkaConsumer: KafkaConsumer<String, ConsumerRecordValue>,
+    )
+}

--- a/src/main/kotlin/no/nav/syfo/infrastructure/kafka/KafkaConsumerTask.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/kafka/KafkaConsumerTask.kt
@@ -1,0 +1,32 @@
+package no.nav.syfo.infrastructure.kafka
+
+import no.nav.syfo.ApplicationState
+import no.nav.syfo.launchBackgroundTask
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.util.*
+
+val log: Logger = LoggerFactory.getLogger("no.nav.syfo")
+
+inline fun <reified ConsumerRecordValue> launchKafkaConsumer(
+    applicationState: ApplicationState,
+    topic: String,
+    consumerProperties: Properties,
+    kafkaConsumerService: KafkaConsumerService<ConsumerRecordValue>,
+) {
+    launchBackgroundTask(
+        applicationState = applicationState
+    ) {
+        log.info("Setting up kafka consumer for ${ConsumerRecordValue::class.java.simpleName}")
+
+        val kafkaConsumer = KafkaConsumer<String, ConsumerRecordValue>(consumerProperties)
+
+        while (applicationState.ready) {
+            if (kafkaConsumer.subscription().isEmpty()) {
+                kafkaConsumer.subscribe(listOf(topic))
+            }
+            kafkaConsumerService.pollAndProcessRecords(kafkaConsumer)
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/infrastructure/kafka/KafkaEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/kafka/KafkaEnvironment.kt
@@ -6,4 +6,7 @@ class KafkaEnvironment(
     val aivenTruststoreLocation: String,
     val aivenSecurityProtocol: String,
     val aivenBootstrapServers: String,
+    val aivenSchemaRegistryUrl: String,
+    val aivenRegistryUser: String,
+    val aivenRegistryPassword: String,
 )

--- a/src/main/kotlin/no/nav/syfo/infrastructure/kafka/identhendelse/IdenthendelseConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/kafka/identhendelse/IdenthendelseConsumer.kt
@@ -1,35 +1,20 @@
 package no.nav.syfo.infrastructure.kafka.identhendelse
 
-import kotlinx.coroutines.delay
 import no.nav.syfo.infrastructure.kafka.KafkaConsumerService
 import org.apache.avro.generic.GenericRecord
 import org.apache.kafka.clients.consumer.KafkaConsumer
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 import java.time.Duration
-import kotlin.time.Duration.Companion.seconds
 
 class IdenthendelseConsumer(private val identhendelseService: IdenthendelseService) : KafkaConsumerService<GenericRecord> {
     override val pollDurationInMillis: Long = 1000
 
     override suspend fun pollAndProcessRecords(kafkaConsumer: KafkaConsumer<String, GenericRecord>) {
-        runCatching {
-            val records = kafkaConsumer.poll(Duration.ofMillis(pollDurationInMillis))
-            if (records.count() > 0) {
-                records.mapNotNull { it.value() }.forEach {
-                    identhendelseService.handle(identhendelse = it.toKafkaIdenthendelseDTO())
-                }
-                kafkaConsumer.commitSync()
+        val records = kafkaConsumer.poll(Duration.ofMillis(pollDurationInMillis))
+        if (records.count() > 0) {
+            records.mapNotNull { it.value() }.forEach {
+                identhendelseService.handle(identhendelse = it.toKafkaIdenthendelseDTO())
             }
-        }.onFailure { ex ->
-            log.warn("Error running kafka consumer for pdl-aktor, unsubscribing and waiting $DELAY_ON_ERROR_SECONDS seconds for retry", ex)
-            kafkaConsumer.unsubscribe()
-            delay(DELAY_ON_ERROR_SECONDS.seconds)
+            kafkaConsumer.commitSync()
         }
-    }
-
-    companion object {
-        private const val DELAY_ON_ERROR_SECONDS = 60L
-        private val log: Logger = LoggerFactory.getLogger(this::class.java)
     }
 }

--- a/src/main/kotlin/no/nav/syfo/infrastructure/kafka/identhendelse/IdenthendelseConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/kafka/identhendelse/IdenthendelseConsumer.kt
@@ -1,0 +1,35 @@
+package no.nav.syfo.infrastructure.kafka.identhendelse
+
+import kotlinx.coroutines.delay
+import no.nav.syfo.infrastructure.kafka.KafkaConsumerService
+import org.apache.avro.generic.GenericRecord
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+class IdenthendelseConsumer(private val identhendelseService: IdenthendelseService) : KafkaConsumerService<GenericRecord> {
+    override val pollDurationInMillis: Long = 1000
+
+    override suspend fun pollAndProcessRecords(kafkaConsumer: KafkaConsumer<String, GenericRecord>) {
+        runCatching {
+            val records = kafkaConsumer.poll(Duration.ofMillis(pollDurationInMillis))
+            if (records.count() > 0) {
+                records.mapNotNull { it.value() }.forEach {
+                    identhendelseService.handle(identhendelse = it.toKafkaIdenthendelseDTO())
+                }
+                kafkaConsumer.commitSync()
+            }
+        }.onFailure { ex ->
+            log.warn("Error running kafka consumer for pdl-aktor, unsubscribing and waiting $DELAY_ON_ERROR_SECONDS seconds for retry", ex)
+            kafkaConsumer.unsubscribe()
+            delay(DELAY_ON_ERROR_SECONDS.seconds)
+        }
+    }
+
+    companion object {
+        private const val DELAY_ON_ERROR_SECONDS = 60L
+        private val log: Logger = LoggerFactory.getLogger(this::class.java)
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/infrastructure/kafka/identhendelse/IdenthendelseKafkaTask.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/kafka/identhendelse/IdenthendelseKafkaTask.kt
@@ -1,0 +1,36 @@
+package no.nav.syfo.infrastructure.kafka.identhendelse
+
+import io.confluent.kafka.serializers.KafkaAvroDeserializer
+import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig
+import no.nav.syfo.ApplicationState
+import no.nav.syfo.infrastructure.kafka.KafkaEnvironment
+import no.nav.syfo.infrastructure.kafka.kafkaAivenConsumerConfig
+import no.nav.syfo.infrastructure.kafka.launchKafkaConsumer
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import java.util.*
+
+const val PDL_AKTOR_TOPIC = "pdl.aktor-v2"
+
+fun launchIdenthendelseConsumer(
+    applicationState: ApplicationState,
+    kafkaEnvironment: KafkaEnvironment,
+    identhendelseConsumer: IdenthendelseConsumer,
+) {
+    val consumerProperties = Properties().apply {
+        putAll(kafkaAivenConsumerConfig<KafkaAvroDeserializer>(kafkaEnvironment))
+        this[ConsumerConfig.MAX_POLL_RECORDS_CONFIG] = "1"
+
+        this[KafkaAvroDeserializerConfig.SCHEMA_REGISTRY_URL_CONFIG] = kafkaEnvironment.aivenSchemaRegistryUrl
+        this[KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG] = false
+        this[KafkaAvroDeserializerConfig.USER_INFO_CONFIG] =
+            "${kafkaEnvironment.aivenRegistryUser}:${kafkaEnvironment.aivenRegistryPassword}"
+        this[KafkaAvroDeserializerConfig.BASIC_AUTH_CREDENTIALS_SOURCE] = "USER_INFO"
+    }
+
+    launchKafkaConsumer(
+        applicationState = applicationState,
+        topic = PDL_AKTOR_TOPIC,
+        consumerProperties = consumerProperties,
+        kafkaConsumerService = identhendelseConsumer
+    )
+}

--- a/src/main/kotlin/no/nav/syfo/infrastructure/kafka/identhendelse/IdenthendelseKafkaTask.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/kafka/identhendelse/IdenthendelseKafkaTask.kt
@@ -6,7 +6,6 @@ import no.nav.syfo.ApplicationState
 import no.nav.syfo.infrastructure.kafka.KafkaEnvironment
 import no.nav.syfo.infrastructure.kafka.kafkaAivenConsumerConfig
 import no.nav.syfo.infrastructure.kafka.launchKafkaConsumer
-import org.apache.kafka.clients.consumer.ConsumerConfig
 import java.util.*
 
 const val PDL_AKTOR_TOPIC = "pdl.aktor-v2"
@@ -18,8 +17,6 @@ fun launchIdenthendelseConsumer(
 ) {
     val consumerProperties = Properties().apply {
         putAll(kafkaAivenConsumerConfig<KafkaAvroDeserializer>(kafkaEnvironment))
-        this[ConsumerConfig.MAX_POLL_RECORDS_CONFIG] = "1"
-
         this[KafkaAvroDeserializerConfig.SCHEMA_REGISTRY_URL_CONFIG] = kafkaEnvironment.aivenSchemaRegistryUrl
         this[KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG] = false
         this[KafkaAvroDeserializerConfig.USER_INFO_CONFIG] =

--- a/src/main/kotlin/no/nav/syfo/infrastructure/kafka/identhendelse/IdenthendelseService.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/kafka/identhendelse/IdenthendelseService.kt
@@ -1,0 +1,29 @@
+package no.nav.syfo.infrastructure.kafka.identhendelse
+
+import no.nav.syfo.infrastructure.database.repository.VurderingRepository
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+class IdenthendelseService(private val vurderingRepository: VurderingRepository) {
+
+    fun handle(identhendelse: KafkaIdenthendelseDTO) {
+        val (aktivIdent, inaktiveIdenter) = identhendelse.getFolkeregisterIdenter()
+        if (aktivIdent != null) {
+            val vurderingerMedInaktivIdent = inaktiveIdenter.flatMap { vurderingRepository.getVurderinger(it) }
+
+            if (vurderingerMedInaktivIdent.isNotEmpty()) {
+                vurderingRepository.updatePersonident(
+                    nyPersonident = aktivIdent,
+                    vurderinger = vurderingerMedInaktivIdent,
+                )
+                log.info("Identhendelse: Updated ${vurderingerMedInaktivIdent.size} vurderinger based on Identhendelse from PDL")
+            }
+        } else {
+            log.warn("Identhendelse ignored - Mangler aktiv ident i PDL")
+        }
+    }
+
+    companion object {
+        private val log: Logger = LoggerFactory.getLogger(this::class.java)
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/infrastructure/kafka/identhendelse/KafkaIdenthendelseDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/kafka/identhendelse/KafkaIdenthendelseDTO.kt
@@ -1,0 +1,46 @@
+package no.nav.syfo.infrastructure.kafka.identhendelse
+
+import no.nav.syfo.domain.PersonIdent
+import org.apache.avro.generic.GenericData
+import org.apache.avro.generic.GenericRecord
+
+// Basert på https://github.com/navikt/pdl/blob/master/libs/contract-pdl-avro/src/main/avro/no/nav/person/pdl/aktor/AktorV2.avdl
+
+data class KafkaIdenthendelseDTO(
+    val identifikatorer: List<Identifikator>,
+)
+
+data class Identifikator(
+    val idnummer: String,
+    val type: IdentType,
+    val gjeldende: Boolean,
+)
+
+enum class IdentType {
+    FOLKEREGISTERIDENT,
+    AKTORID,
+    NPID,
+}
+
+fun KafkaIdenthendelseDTO.getFolkeregisterIdenter(): Pair<PersonIdent?, List<PersonIdent>> {
+    val (aktive, inaktive) = identifikatorer.filter { it.type == IdentType.FOLKEREGISTERIDENT }.partition { it.gjeldende }
+    val aktivIdent = aktive.firstOrNull()?.let { PersonIdent(it.idnummer) }
+
+    return Pair(aktivIdent, inaktive.map { PersonIdent(it.idnummer) })
+}
+
+fun GenericRecord.toKafkaIdenthendelseDTO(): KafkaIdenthendelseDTO {
+    val identifikatorer = (get("identifikatorer") as GenericData.Array<GenericRecord>).map {
+        Identifikator(
+            idnummer = it.get("idnummer").toString(),
+            gjeldende = it.get("gjeldende").toString().toBoolean(),
+            type = when (it.get("type").toString()) {
+                "FOLKEREGISTERIDENT" -> IdentType.FOLKEREGISTERIDENT
+                "AKTORID" -> IdentType.AKTORID
+                "NPID" -> IdentType.NPID
+                else -> throw IllegalStateException("Har mottatt ident med ukjent type")
+            }
+        )
+    }
+    return KafkaIdenthendelseDTO(identifikatorer)
+}

--- a/src/test/kotlin/no/nav/syfo/TestEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/TestEnvironment.kt
@@ -21,6 +21,9 @@ fun testEnvironment() = Environment(
         aivenKeystoreLocation = "keystore",
         aivenSecurityProtocol = "SSL",
         aivenTruststoreLocation = "truststore",
+        aivenSchemaRegistryUrl = "http://kafka-schema-registry.tpa.svc.nais.local:8081",
+        aivenRegistryUser = "registryuser",
+        aivenRegistryPassword = "registrypassword",
     ),
     azure = AzureEnvironment(
         appClientId = "isarbeidsuforhet-client-id",

--- a/src/test/kotlin/no/nav/syfo/generator/IdenthendelseGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/generator/IdenthendelseGenerator.kt
@@ -1,0 +1,18 @@
+package no.nav.syfo.generator
+
+import no.nav.syfo.domain.PersonIdent
+import no.nav.syfo.infrastructure.kafka.identhendelse.IdentType
+import no.nav.syfo.infrastructure.kafka.identhendelse.Identifikator
+import no.nav.syfo.infrastructure.kafka.identhendelse.KafkaIdenthendelseDTO
+
+fun generateIdenthendelse(
+    aktivIdent: PersonIdent?,
+    inaktiveIdenter: List<PersonIdent>
+): KafkaIdenthendelseDTO {
+    val identifikatorer = inaktiveIdenter.map { Identifikator(idnummer = it.value, gjeldende = false, type = IdentType.FOLKEREGISTERIDENT) }.toMutableList()
+    aktivIdent?.let { identifikatorer.add(Identifikator(idnummer = it.value, gjeldende = true, type = IdentType.FOLKEREGISTERIDENT)) }
+
+    return KafkaIdenthendelseDTO(
+        identifikatorer = identifikatorer
+    )
+}

--- a/src/test/kotlin/no/nav/syfo/infrastructure/identhendelse/IdenthendelseServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/identhendelse/IdenthendelseServiceSpek.kt
@@ -1,0 +1,117 @@
+package no.nav.syfo.infrastructure.identhendelse
+
+import no.nav.syfo.ExternalMockEnvironment
+import no.nav.syfo.UserConstants
+import no.nav.syfo.domain.VurderingType
+import no.nav.syfo.generator.generateIdenthendelse
+import no.nav.syfo.generator.generateVurdering
+import no.nav.syfo.infrastructure.database.dropData
+import no.nav.syfo.infrastructure.database.repository.VurderingRepository
+import no.nav.syfo.infrastructure.kafka.identhendelse.IdenthendelseService
+import org.amshove.kluent.shouldBeEmpty
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldNotBeEmpty
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+private val aktivIdent = UserConstants.ARBEIDSTAKER_PERSONIDENT
+private val inaktivIdent = UserConstants.ARBEIDSTAKER_3_PERSONIDENT
+private val annenInaktivIdent = UserConstants.ARBEIDSTAKER_2_PERSONIDENT
+
+class IdenthendelseServiceSpek : Spek({
+    describe(IdenthendelseService::class.java.simpleName) {
+        val externalMockEnvironment = ExternalMockEnvironment.instance
+        val database = externalMockEnvironment.database
+        val vurderingRepository = VurderingRepository(database = database)
+        val identhendelseService = IdenthendelseService(
+            vurderingRepository = vurderingRepository,
+        )
+
+        beforeEachTest {
+            database.dropData()
+        }
+
+        val vurderingMedInaktivIdent = generateVurdering(personident = inaktivIdent, type = VurderingType.OPPFYLT)
+        val vurderingMedAnnenInaktivIdent = generateVurdering(personident = annenInaktivIdent, type = VurderingType.AVSLAG)
+
+        it("Flytter vurdering fra inaktiv ident til ny ident når person får ny ident") {
+            vurderingRepository.createVurdering(
+                vurdering = vurderingMedInaktivIdent,
+                pdf = UserConstants.PDF_VURDERING
+            )
+
+            val identhendelse = generateIdenthendelse(
+                aktivIdent = aktivIdent,
+                inaktiveIdenter = listOf(inaktivIdent)
+            )
+            identhendelseService.handle(identhendelse)
+
+            vurderingRepository.getVurderinger(personident = inaktivIdent).shouldBeEmpty()
+            vurderingRepository.getVurderinger(personident = aktivIdent).shouldNotBeEmpty()
+        }
+
+        it("Flytter vurderinger fra inaktive identer når person for ny ident") {
+            vurderingRepository.createVurdering(
+                vurdering = vurderingMedInaktivIdent,
+                pdf = UserConstants.PDF_VURDERING
+            )
+            vurderingRepository.createVurdering(
+                vurdering = vurderingMedAnnenInaktivIdent,
+                pdf = UserConstants.PDF_VURDERING
+            )
+
+            val identhendelse = generateIdenthendelse(
+                aktivIdent = aktivIdent,
+                inaktiveIdenter = listOf(inaktivIdent, annenInaktivIdent)
+            )
+            identhendelseService.handle(identhendelse)
+
+            vurderingRepository.getVurderinger(personident = inaktivIdent).shouldBeEmpty()
+            vurderingRepository.getVurderinger(personident = annenInaktivIdent).shouldBeEmpty()
+            vurderingRepository.getVurderinger(personident = aktivIdent).size shouldBeEqualTo 2
+        }
+
+        it("Oppdaterer ingenting når person får ny ident og uten vurdering på inaktiv ident") {
+            val identhendelse = generateIdenthendelse(
+                aktivIdent = aktivIdent,
+                inaktiveIdenter = listOf(inaktivIdent)
+            )
+            identhendelseService.handle(identhendelse)
+
+            vurderingRepository.getVurderinger(personident = inaktivIdent).shouldBeEmpty()
+            vurderingRepository.getVurderinger(personident = aktivIdent).shouldBeEmpty()
+        }
+
+        it("Oppdaterer ingenting når person får ny ident uten inaktiv identer") {
+            vurderingRepository.createVurdering(
+                vurdering = vurderingMedInaktivIdent,
+                pdf = UserConstants.PDF_VURDERING
+            )
+
+            val identhendelse = generateIdenthendelse(
+                aktivIdent = aktivIdent,
+                inaktiveIdenter = emptyList()
+            )
+            identhendelseService.handle(identhendelse)
+
+            vurderingRepository.getVurderinger(personident = inaktivIdent).shouldNotBeEmpty()
+            vurderingRepository.getVurderinger(personident = aktivIdent).shouldBeEmpty()
+        }
+
+        it("Oppdaterer ingenting når person mangler aktiv ident") {
+            vurderingRepository.createVurdering(
+                vurdering = vurderingMedInaktivIdent,
+                pdf = UserConstants.PDF_VURDERING
+            )
+
+            val identhendelse = generateIdenthendelse(
+                aktivIdent = null,
+                inaktiveIdenter = listOf(inaktivIdent)
+            )
+            identhendelseService.handle(identhendelse)
+
+            vurderingRepository.getVurderinger(personident = inaktivIdent).shouldNotBeEmpty()
+            vurderingRepository.getVurderinger(personident = aktivIdent).shouldBeEmpty()
+        }
+    }
+})


### PR DESCRIPTION
Leser inn alle identhendelser fra PDL og flytter vurderinger til ny (aktiv) ident der hvor det forekommer vurdering på inaktiv ident. Se for øvrig https://github.com/navikt/ishuskelapp/pull/110 for tilsvarende PR.