### PR TITLE
IS-3180: Create one-time job to generate new forhandsvarsler for non-notified varsler

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -87,3 +87,5 @@ spec:
       value: "dev-fss.teamdokumenthandtering.dokarkiv-q1"
     - name: DOKARKIV_URL
       value: "https://dokarkiv.dev-fss-pub.nais.io"
+    - name: REPUBLISH_FORHANDSVARSEL_WITH_ADDITIONAL_INFO_CRONJOB_ENABLED
+      value: "true"

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -88,4 +88,4 @@ spec:
     - name: DOKARKIV_URL
       value: "https://dokarkiv.prod-fss-pub.nais.io"
     - name: REPUBLISH_FORHANDSVARSEL_WITH_ADDITIONAL_INFO_CRONJOB_ENABLED
-      value: "false"
+      value: "true"

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -87,3 +87,5 @@ spec:
       value: "prod-fss.teamdokumenthandtering.dokarkiv"
     - name: DOKARKIV_URL
       value: "https://dokarkiv.prod-fss-pub.nais.io"
+    - name: REPUBLISH_FORHANDSVARSEL_WITH_ADDITIONAL_INFO_CRONJOB_ENABLED
+      value: "false"

--- a/src/main/kotlin/no/nav/syfo/ApplicationEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/ApplicationEnvironment.kt
@@ -55,6 +55,7 @@ data class Environment(
                 clientId = getEnvVar("DOKARKIV_CLIENT_ID"),
             ),
         ),
+    val republishForhandsvarselWithAdditionalInfoCronjobEnabled: Boolean = getEnvVar("REPUBLISH_FORHANDSVARSEL_WITH_ADDITIONAL_INFO_CRONJOB_ENABLED").toBoolean(),
 )
 
 fun getEnvVar(

--- a/src/main/kotlin/no/nav/syfo/application/IVurderingRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/application/IVurderingRepository.kt
@@ -2,6 +2,7 @@ package no.nav.syfo.application
 
 import no.nav.syfo.domain.PersonIdent
 import no.nav.syfo.domain.Vurdering
+import java.util.*
 
 interface IVurderingRepository {
     fun getVurderinger(
@@ -26,4 +27,6 @@ interface IVurderingRepository {
     fun getNotJournalforteVurderinger(): List<Pair<Vurdering, ByteArray>>
 
     fun updatePersonident(nyPersonident: PersonIdent, vurderinger: List<Vurdering>)
+
+    fun getVurdering(uuid: UUID): Vurdering?
 }

--- a/src/main/kotlin/no/nav/syfo/application/service/VurderingService.kt
+++ b/src/main/kotlin/no/nav/syfo/application/service/VurderingService.kt
@@ -9,6 +9,7 @@ import no.nav.syfo.domain.*
 import no.nav.syfo.infrastructure.metric.METRICS_NS
 import no.nav.syfo.infrastructure.metric.METRICS_REGISTRY
 import java.time.LocalDate
+import java.util.UUID
 
 class VurderingService(
     private val vurderingRepository: IVurderingRepository,
@@ -34,9 +35,10 @@ class VurderingService(
         gjelderFom: LocalDate?,
         svarfrist: LocalDate? = null,
         callId: String,
+        overrideForhandsvarselChecks: Boolean = false,
     ): Vurdering {
         val currentVurdering = getVurderinger(personident).firstOrNull()
-        if (type == VurderingType.FORHANDSVARSEL && currentVurdering is Vurdering.Forhandsvarsel) {
+        if (!overrideForhandsvarselChecks && (type == VurderingType.FORHANDSVARSEL && currentVurdering is Vurdering.Forhandsvarsel)) {
             throw IllegalArgumentException("Duplicate ${VurderingType.FORHANDSVARSEL} for given person")
         }
         if (type == VurderingType.FORHANDSVARSEL && svarfrist == null) {
@@ -126,6 +128,8 @@ class VurderingService(
             }
         }
     }
+
+    fun getVurdering(uuid: UUID): Vurdering? = vurderingRepository.getVurdering(uuid)
 }
 
 private class Metrics {

--- a/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/CronjobModule.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/CronjobModule.kt
@@ -48,6 +48,7 @@ fun launchCronjobs(
 }
 
 val UUIDS = listOf(
+    "8e70a999-cf7e-4fc3-aa10-7b7e66fc7437",
     "9db72978-e5ea-4b78-bd64-232635ad79bd",
     "a58440a7-f2f6-441b-8fc7-2f6402cdb8c9",
     "4b018f3f-db57-4be6-bd7e-99bb7ba369a0",

--- a/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/CronjobModule.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/CronjobModule.kt
@@ -48,6 +48,7 @@ fun launchCronjobs(
 }
 
 val UUIDS = listOf(
+    "18bfe934-47e6-4c99-8232-94293be4d889",
     "9db72978-e5ea-4b78-bd64-232635ad79bd",
     "a58440a7-f2f6-441b-8fc7-2f6402cdb8c9",
     "4b018f3f-db57-4be6-bd7e-99bb7ba369a0",

--- a/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/CronjobModule.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/CronjobModule.kt
@@ -31,6 +31,13 @@ fun launchCronjobs(
     val publishVurderingerCronJob = PublishVurderingerCronjob(vurderingService = vurderingService)
     cronjobs.add(publishVurderingerCronJob)
 
+    if (environment.republishForhandsvarselWithAdditionalInfoCronjobEnabled) {
+        val republishForhandsvarselWithAdditionalInfoCronjob = RepublishForhandsvarselWithAdditionalInfoCronjob(
+            vurderingService = vurderingService,
+            uuids = UUIDS,
+        )
+        cronjobs.add(republishForhandsvarselWithAdditionalInfoCronjob)
+    }
     cronjobs.forEach {
         launchBackgroundTask(
             applicationState = applicationState,
@@ -39,3 +46,6 @@ fun launchCronjobs(
         }
     }
 }
+
+// TODO: Add UUIDs to update
+val UUIDS = listOf("")

--- a/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/CronjobModule.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/CronjobModule.kt
@@ -47,4 +47,4 @@ fun launchCronjobs(
     }
 }
 
-val UUIDS = listOf("ba7c38cc-5190-4d04-ac89-f18d9f4a5290")
+val UUIDS = listOf("38eae7a7-c82f-47c9-8bf5-d8634d42f4ac")

--- a/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/CronjobModule.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/CronjobModule.kt
@@ -48,7 +48,6 @@ fun launchCronjobs(
 }
 
 val UUIDS = listOf(
-    "8e70a999-cf7e-4fc3-aa10-7b7e66fc7437",
     "9db72978-e5ea-4b78-bd64-232635ad79bd",
     "a58440a7-f2f6-441b-8fc7-2f6402cdb8c9",
     "4b018f3f-db57-4be6-bd7e-99bb7ba369a0",

--- a/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/CronjobModule.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/CronjobModule.kt
@@ -47,4 +47,4 @@ fun launchCronjobs(
     }
 }
 
-val UUIDS = listOf("38eae7a7-c82f-47c9-8bf5-d8634d42f4ac")
+val UUIDS = listOf("38eae7a7-c82f-47c9-8bf5-d8634d42f4ac", "1e47f57f-5a0b-488e-b2a2-87976e893147")

--- a/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/CronjobModule.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/CronjobModule.kt
@@ -47,4 +47,29 @@ fun launchCronjobs(
     }
 }
 
-val UUIDS = listOf("38eae7a7-c82f-47c9-8bf5-d8634d42f4ac", "1e47f57f-5a0b-488e-b2a2-87976e893147")
+val UUIDS = listOf(
+    "9db72978-e5ea-4b78-bd64-232635ad79bd",
+    "a58440a7-f2f6-441b-8fc7-2f6402cdb8c9",
+    "4b018f3f-db57-4be6-bd7e-99bb7ba369a0",
+    "d819ad96-2f46-4c60-b24d-2f03f5e6e159",
+    "b035c5c9-89d7-4b7a-b0fb-2dd0e3cdf885",
+    "0a52e4c8-507f-4f4a-8919-b3efc203c284",
+    "034d1e2f-68d0-493d-8bba-4816ec1f9823",
+    "8d7d8d11-518a-499e-a55d-f6b70f3e428d",
+    "55ea3696-e7f4-419b-9dfd-53e4d7564df1",
+    "9666d05f-1e32-43ba-bd49-ac5f9e8232e3",
+    "e6206b7e-bfe0-4ebf-a3b9-c6b6e7bfdb4d",
+    "3bcf34be-fcf2-4ffc-a569-88ba92c6c628",
+    "dec0190e-6d6f-4471-bc72-3dfc69362ab8",
+    "c4d20bf1-3dc7-4f81-96a4-91dd184a1e34",
+    "ad697ddf-2a87-4803-8527-bdc81cdc704a",
+    "9aeec2a3-5596-4f21-9fc9-dde55b5bb9a6",
+    "0ccae971-22cc-4f55-b735-0b4504fc7316",
+    "2bb189d6-d8a2-4c9b-8015-ee2518c263fa",
+    "0282fa83-30ff-4f2f-a9a6-cf6c543c3e89",
+    "83c21643-6166-49bc-b1e8-dcbbacb86726",
+    "8187c795-ebc1-4298-b595-1375c136c09c",
+    "8309236e-54a6-4d31-a819-4be147d7be16",
+    "cc1dc9dc-859d-40ee-bb6c-52175c611d1f",
+    "4f734d05-f7dd-4ef5-aecd-71439c294f88"
+)

--- a/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/CronjobModule.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/CronjobModule.kt
@@ -47,5 +47,4 @@ fun launchCronjobs(
     }
 }
 
-// TODO: Add UUIDs to update
-val UUIDS = listOf("")
+val UUIDS = listOf("ba7c38cc-5190-4d04-ac89-f18d9f4a5290")

--- a/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/CronjobModule.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/CronjobModule.kt
@@ -48,7 +48,6 @@ fun launchCronjobs(
 }
 
 val UUIDS = listOf(
-    "18bfe934-47e6-4c99-8232-94293be4d889",
     "9db72978-e5ea-4b78-bd64-232635ad79bd",
     "a58440a7-f2f6-441b-8fc7-2f6402cdb8c9",
     "4b018f3f-db57-4be6-bd7e-99bb7ba369a0",

--- a/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/RepublishForhandsvarselWithAdditionalInfoCronjob.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/RepublishForhandsvarselWithAdditionalInfoCronjob.kt
@@ -19,7 +19,7 @@ class RepublishForhandsvarselWithAdditionalInfoCronjob(
     private val log = LoggerFactory.getLogger(RepublishForhandsvarselWithAdditionalInfoCronjob::class.java)
 
     override suspend fun run(): List<Result<Vurdering>> {
-        val newFrist = LocalDate.of(2025, 4, 7) // 7. april 2025
+        val newFrist = LocalDate.of(2025, 4, 9) // 7. april 2025
         val result = uuids.map { uuid ->
             try {
                 val vurdering = vurderingService.getVurdering(UUID.fromString(uuid))

--- a/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/RepublishForhandsvarselWithAdditionalInfoCronjob.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/RepublishForhandsvarselWithAdditionalInfoCronjob.kt
@@ -1,0 +1,106 @@
+package no.nav.syfo.infrastructure.cronjob
+
+import no.nav.syfo.application.service.VurderingService
+import no.nav.syfo.domain.DocumentComponent
+import no.nav.syfo.domain.DocumentComponentType
+import no.nav.syfo.domain.Vurdering
+import org.slf4j.LoggerFactory
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.util.*
+
+class RepublishForhandsvarselWithAdditionalInfoCronjob(
+    private val vurderingService: VurderingService,
+    private val uuids: List<String> = emptyList(),
+) : Cronjob {
+    override val initialDelayMinutes: Long = 4
+    override val intervalDelayMinutes: Long = 10000000
+
+    private val log = LoggerFactory.getLogger(RepublishForhandsvarselWithAdditionalInfoCronjob::class.java)
+
+    override suspend fun run(): List<Result<Vurdering>> {
+        val newFrist = LocalDate.of(2025, 4, 7) // 7. april 2025
+        val result = uuids.map { uuid ->
+            try {
+                val vurdering = vurderingService.getVurdering(UUID.fromString(uuid))
+                if (vurdering != null) {
+                    val newDocument = generateNewDocument(vurdering, newFrist)
+                    val newVurdering = vurderingService.createVurdering(
+                        personident = vurdering.personident,
+                        veilederident = vurdering.veilederident,
+                        type = vurdering.type,
+                        arsak = vurdering.arsak,
+                        begrunnelse = vurdering.begrunnelse,
+                        document = newDocument,
+                        gjelderFom = vurdering.gjelderFom,
+                        svarfrist = newFrist,
+                        callId = "cronjob-republish-forhandsvarsel",
+                        overrideForhandsvarselChecks = true,
+                    )
+                    Result.success(newVurdering)
+                } else {
+                    Result.failure(IllegalArgumentException("Vurdering with UUID $uuid not found"))
+                }
+            } catch (e: Exception) {
+                log.error("Exception caught while attempting to republish forhandsvarsel with UUID $uuid", e)
+                Result.failure(e)
+            }
+        }
+        log.info(
+            """
+            Updated ${result.count { it.isSuccess }} forhandsvarsler in ${RepublishForhandsvarselWithAdditionalInfoCronjob::class.java.simpleName}.
+            UUIDs for new forhandsvarsler: ${result.filter { it.isSuccess }.joinToString(", ") { it.getOrNull()?.uuid.toString() }}
+            """.trimIndent()
+        )
+
+        return result
+    }
+
+    private fun generateNewDocument(vurdering: Vurdering, newFrist: LocalDate): List<DocumentComponent> {
+        return vurdering.document.map { documentComponent ->
+            if (documentComponent.type == DocumentComponentType.PARAGRAPH &&
+                documentComponent.texts.any { it.contains("Nav vurderer å avslå sykepengene dine fra og med") }
+            ) {
+                val extraText = "OBS! På grunn av en teknisk feil på vår side, har vi ikke klart å varsle deg om dette brevet tidligere. Vi beklager ulempen. Vi har derfor forlenget fristen for å svare til ${newFrist.format(
+                    DateTimeFormatter.ofPattern("dd.MM.yyyy")
+                )}. Dette brevet er en eksakt kopi av det du skulle ha mottatt tidligere, men med ny utvidet frist."
+                DocumentComponent(
+                    type = DocumentComponentType.PARAGRAPH,
+                    title = null,
+                    texts = listOf(
+                        extraText,
+                        "Nav vurderer å avslå sykepengene dine fra og med ${newFrist.format(
+                            DateTimeFormatter.ofPattern("dd.MM.yyyy")
+                        )}."
+                    )
+                )
+            } else if (documentComponent.type == DocumentComponentType.PARAGRAPH &&
+                documentComponent.texts.any { it.contains("Vi sender deg dette brevet for at du skal ha mulighet til å uttale deg før vi avgjør saken din. Du må sende inn opplysninger eller kontakte oss innen") }
+            ) {
+                DocumentComponent(
+                    type = DocumentComponentType.PARAGRAPH,
+                    title = null,
+                    texts = listOf(
+                        "Vi sender deg dette brevet for at du skal ha mulighet til å uttale deg før vi avgjør saken din. Du må sende inn opplysninger eller kontakte oss innen ${newFrist.format(
+                            DateTimeFormatter.ofPattern("dd.MM.yyyy")
+                        )}."
+                    )
+                )
+            } else if (documentComponent.type == DocumentComponentType.PARAGRAPH &&
+                documentComponent.texts.any { it.contains("Dersom du blir friskmeldt før") }
+            ) {
+                DocumentComponent(
+                    type = DocumentComponentType.PARAGRAPH,
+                    title = null,
+                    texts = listOf(
+                        "Dersom du blir friskmeldt før ${newFrist.format(
+                            DateTimeFormatter.ofPattern("dd.MM.yyyy")
+                        )} kan du se bort fra dette brevet."
+                    )
+                )
+            } else {
+                documentComponent
+            }
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/RepublishForhandsvarselWithAdditionalInfoCronjob.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/RepublishForhandsvarselWithAdditionalInfoCronjob.kt
@@ -20,12 +20,13 @@ class RepublishForhandsvarselWithAdditionalInfoCronjob(
 
     override suspend fun run(): List<Result<Vurdering>> {
         val newFrist = LocalDate.of(2025, 4, 9) // 7. april 2025
-        val result = uuids.map { uuid ->
+        val result = uuids.map { uuidString ->
             try {
-                val vurdering = vurderingService.getVurdering(UUID.fromString(uuid))
+                val uuid = UUID.fromString(uuidString)
+                val vurdering = vurderingService.getVurdering(uuid)
                 if (vurdering != null) {
                     val vurderingerForPerson = vurderingService.getVurderinger(vurdering.personident)
-                    if (vurderingerForPerson.firstOrNull().uuid == uuid) {
+                    if (vurderingerForPerson.firstOrNull()?.uuid == uuid) {
                         val newDocument = generateNewDocument(vurdering, newFrist)
                         val newVurdering = vurderingService.createVurdering(
                             personident = vurdering.personident,
@@ -47,7 +48,7 @@ class RepublishForhandsvarselWithAdditionalInfoCronjob(
                     Result.failure(IllegalArgumentException("Vurdering with UUID $uuid not found"))
                 }
             } catch (e: Exception) {
-                log.error("Exception caught while attempting to republish forhandsvarsel with UUID $uuid", e)
+                log.error("Exception caught while attempting to republish forhandsvarsel with UUID $uuidString", e)
                 Result.failure(e)
             }
         }

--- a/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/RepublishForhandsvarselWithAdditionalInfoCronjob.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/cronjob/RepublishForhandsvarselWithAdditionalInfoCronjob.kt
@@ -67,7 +67,7 @@ class RepublishForhandsvarselWithAdditionalInfoCronjob(
             if (documentComponent.type == DocumentComponentType.PARAGRAPH &&
                 documentComponent.texts.any { it.contains("Nav vurderer å avslå sykepengene dine fra og med") }
             ) {
-                val extraText = "Viktig informasjon: På grunn av en teknisk feil, har vi ikke klart å varsle deg om dette brevet tidligere. Vi beklager ulempen. På grunn av denne feilen mottar du derfor et nytt brev, med ny frist for tilbakemelding. Dette brevet erstatter tidligere brev som du ikke ble varslet om, og det er kun dette brevet du skal forholde deg til. Det opprinnelige brevet kan du finne under Mine dokumenter på innloggede sider på nav.no.\n"
+                val extraText = "Viktig informasjon: På grunn av en teknisk feil, har vi ikke klart å varsle deg om dette brevet tidligere. Vi beklager ulempen. Dette brevet erstatter tidligere brev som du ikke ble varslet om, og det er kun dette brevet du skal forholde deg til. Det opprinnelige brevet kan du finne under Mine dokumenter på innloggede sider på nav.no.\n"
                 DocumentComponent(
                     type = DocumentComponentType.PARAGRAPH,
                     title = null,

--- a/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/VurderingRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/VurderingRepository.kt
@@ -151,6 +151,18 @@ class VurderingRepository(private val database: DatabaseInterface) : IVurderingR
         connection.commit()
     }
 
+    override fun getVurdering(uuid: UUID): Vurdering? =
+        database.connection.use { connection ->
+            connection.prepareStatement(GET_VURDERING_BY_UUID).use {
+                it.setString(1, uuid.toString())
+                it.executeQuery().toList { toPVurdering() }
+            }.map {
+                it.toVurdering(
+                    varsel = connection.getVarselForVurdering(it)
+                )
+            }.firstOrNull()
+        }
+
     private fun Connection.createVurdering(
         vurdering: Vurdering,
     ): PVurdering {
@@ -297,6 +309,11 @@ class VurderingRepository(private val database: DatabaseInterface) : IVurderingR
                  FROM vurdering vu
                  INNER JOIN vurdering_pdf vup ON vu.id = vup.vurdering_id
                  WHERE vu.journalpost_id IS NULL
+            """
+
+        private const val GET_VURDERING_BY_UUID =
+            """
+                SELECT * FROM VURDERING WHERE uuid=?
             """
     }
 }

--- a/src/test/kotlin/no/nav/syfo/TestEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/TestEnvironment.kt
@@ -50,6 +50,7 @@ fun testEnvironment() = Environment(
     ),
     electorPath = "electorPath",
     isJournalforingRetryEnabled = true,
+    republishForhandsvarselWithAdditionalInfoCronjobEnabled = true,
 )
 
 fun testAppState() = ApplicationState(

--- a/src/test/kotlin/no/nav/syfo/generator/DocumentComponentGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/generator/DocumentComponentGenerator.kt
@@ -2,6 +2,8 @@ package no.nav.syfo.generator
 
 import no.nav.syfo.domain.DocumentComponent
 import no.nav.syfo.domain.DocumentComponentType
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 
 fun generateDocumentComponent(fritekst: String, header: String = "Standard header") = listOf(
     DocumentComponent(
@@ -19,5 +21,89 @@ fun generateDocumentComponent(fritekst: String, header: String = "Standard heade
         key = "Standardtekst",
         title = null,
         texts = listOf("Dette er en standardtekst"),
+    ),
+)
+
+fun generateForhandsvarselRevarslingDocumentComponent(beskrivelse: String, svarfrist: LocalDate) = listOf(
+    DocumentComponent(
+        type = DocumentComponentType.HEADER_H1,
+        title = null,
+        texts = listOf("Nav vurderer å avslå sykepengene dine"),
+    ),
+    DocumentComponent(
+        type = DocumentComponentType.PARAGRAPH,
+        title = null,
+        texts = listOf(
+            "OBS! På grunn av en teknisk feil på vår side, har vi ikke klart å varsle deg om dette brevet tidligere. Vi beklager ulempen. Vi har derfor forlenget fristen for å svare til ${svarfrist.format(
+                DateTimeFormatter.ofPattern("dd.MM.yyyy")
+            )}. Dette brevet er en eksakt kopi av det du skulle ha mottatt tidligere, men med ny utvidet frist.",
+            "Nav vurderer å avslå sykepengene dine fra og med ${svarfrist.format(
+                DateTimeFormatter.ofPattern("dd.MM.yyyy")
+            )}."
+        ),
+    ),
+    DocumentComponent(
+        type = DocumentComponentType.PARAGRAPH,
+        title = null,
+        texts = listOf("For å få sykepenger må du være helt eller delvis ute av stand til å arbeide på grunn av sykdom eller skade."),
+    ),
+    DocumentComponent(
+        type = DocumentComponentType.PARAGRAPH,
+        title = null,
+        texts = listOf(beskrivelse),
+    ),
+    DocumentComponent(
+        type = DocumentComponentType.HEADER_H3,
+        title = null,
+        texts = listOf("Du kan uttale deg"),
+    ),
+    DocumentComponent(
+        type = DocumentComponentType.PARAGRAPH,
+        title = null,
+        texts = listOf(
+            "Vi sender deg dette brevet for at du skal ha mulighet til å uttale deg før vi avgjør saken din. Du må sende inn opplysninger eller kontakte oss innen ${svarfrist.format(
+                DateTimeFormatter.ofPattern("dd.MM.yyyy")
+            )}."
+        ),
+    ),
+    DocumentComponent(
+        type = DocumentComponentType.PARAGRAPH,
+        title = null,
+        texts = listOf("Etter denne datoen vil Nav vurdere å avslå sykepengene dine."),
+    ),
+    DocumentComponent(
+        type = DocumentComponentType.PARAGRAPH,
+        title = null,
+        texts = listOf(
+            "Dersom du blir friskmeldt før ${svarfrist.format(
+                DateTimeFormatter.ofPattern("dd.MM.yyyy")
+            )} kan du se bort fra dette brevet."
+        ),
+    ),
+    DocumentComponent(
+        type = DocumentComponentType.PARAGRAPH,
+        title = null,
+        texts = listOf("Kontakt oss gjerne på nav.no/skriv-til-oss eller telefon 55 55 33 33."),
+    ),
+    DocumentComponent(
+        type = DocumentComponentType.HEADER_H3,
+        title = null,
+        texts = listOf("Lovhjemmel"),
+    ),
+    DocumentComponent(
+        type = DocumentComponentType.PARAGRAPH,
+        title = null,
+        texts = listOf("Krav om arbeidsuførhet er beskrevet i folketrygdloven § 8-4 første ledd."),
+    ),
+    DocumentComponent(
+        type = DocumentComponentType.PARAGRAPH,
+        title = null,
+        texts = listOf("«Sykepenger ytes til den som er arbeidsufør på grunn av en funksjonsnedsettelse som klart skyldes sykdom eller skade. Arbeidsuførhet som skyldes sosiale eller økonomiske problemer o.l., gir ikke rett til sykepenger.»"),
+    ),
+    DocumentComponent(
+        type = DocumentComponentType.PARAGRAPH,
+        key = "Standardtekst",
+        title = null,
+        texts = listOf("Med vennlig hilsen", "VEILEDER_NAVN", "Nav"),
     ),
 )

--- a/src/test/kotlin/no/nav/syfo/infrastructure/cronjob/RepublishForhandsvarselWithAdditionalInfoCronjobSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/cronjob/RepublishForhandsvarselWithAdditionalInfoCronjobSpek.kt
@@ -122,7 +122,7 @@ class RepublishForhandsvarselWithAdditionalInfoCronjobSpek : Spek({
                     vurderinger1.first().varsel?.svarfrist shouldBeEqualTo LocalDate.of(2025, 4, 9)
                     vurderinger1.first().document.filter { documentComponent ->
                         documentComponent.texts.contains(
-                            "Viktig informasjon: På grunn av en teknisk feil, har vi ikke klart å varsle deg om dette brevet tidligere. Vi beklager ulempen. På grunn av denne feilen mottar du derfor et nytt brev, med ny frist for tilbakemelding. Dette brevet erstatter tidligere brev som du ikke ble varslet om, og det er kun dette brevet du skal forholde deg til. Det opprinnelige brevet kan du finne under Mine dokumenter på innloggede sider på nav.no.\n"
+                            "Viktig informasjon: På grunn av en teknisk feil, har vi ikke klart å varsle deg om dette brevet tidligere. Vi beklager ulempen. Dette brevet erstatter tidligere brev som du ikke ble varslet om, og det er kun dette brevet du skal forholde deg til. Det opprinnelige brevet kan du finne under Mine dokumenter på innloggede sider på nav.no.\n"
                         )
                     }.size shouldBeEqualTo 1
                     vurderinger1.first().document.filter { documentComponent ->
@@ -141,7 +141,7 @@ class RepublishForhandsvarselWithAdditionalInfoCronjobSpek : Spek({
                     vurderinger2.first().varsel?.svarfrist shouldBeEqualTo LocalDate.of(2025, 4, 9)
                     vurderinger2.first().document.filter { documentComponent ->
                         documentComponent.texts.contains(
-                            "Viktig informasjon: På grunn av en teknisk feil, har vi ikke klart å varsle deg om dette brevet tidligere. Vi beklager ulempen. På grunn av denne feilen mottar du derfor et nytt brev, med ny frist for tilbakemelding. Dette brevet erstatter tidligere brev som du ikke ble varslet om, og det er kun dette brevet du skal forholde deg til. Det opprinnelige brevet kan du finne under Mine dokumenter på innloggede sider på nav.no.\n"
+                            "Viktig informasjon: På grunn av en teknisk feil, har vi ikke klart å varsle deg om dette brevet tidligere. Vi beklager ulempen. Dette brevet erstatter tidligere brev som du ikke ble varslet om, og det er kun dette brevet du skal forholde deg til. Det opprinnelige brevet kan du finne under Mine dokumenter på innloggede sider på nav.no.\n"
                         )
                     }.size shouldBeEqualTo 1
                     vurderinger2.first().document.filter { documentComponent ->

--- a/src/test/kotlin/no/nav/syfo/infrastructure/cronjob/RepublishForhandsvarselWithAdditionalInfoCronjobSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/cronjob/RepublishForhandsvarselWithAdditionalInfoCronjobSpek.kt
@@ -1,0 +1,159 @@
+package no.nav.syfo.infrastructure.cronjob
+
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import no.nav.syfo.ExternalMockEnvironment
+import no.nav.syfo.UserConstants.ARBEIDSTAKER_2_PERSONIDENT
+import no.nav.syfo.UserConstants.PDF_FORHANDSVARSEL
+import no.nav.syfo.application.service.VurderingService
+import no.nav.syfo.domain.VurderingType
+import no.nav.syfo.generator.generateForhandsvarselRevarslingDocumentComponent
+import no.nav.syfo.generator.generateForhandsvarselVurdering
+import no.nav.syfo.infrastructure.clients.pdfgen.VurderingPdfService
+import no.nav.syfo.infrastructure.database.dropData
+import no.nav.syfo.infrastructure.database.repository.VurderingRepository
+import no.nav.syfo.infrastructure.journalforing.JournalforingService
+import no.nav.syfo.infrastructure.kafka.VurderingProducer
+import no.nav.syfo.infrastructure.kafka.VurderingRecord
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeGreaterThan
+import org.amshove.kluent.shouldBeTrue
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.clients.producer.RecordMetadata
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.util.concurrent.Future
+
+class RepublishForhandsvarselWithAdditionalInfoCronjobSpek : Spek({
+    describe(RepublishForhandsvarselWithAdditionalInfoCronjob::class.java.simpleName) {
+        val externalMockEnvironment = ExternalMockEnvironment.instance
+        val database = externalMockEnvironment.database
+
+        val vurderingRepository = VurderingRepository(database = database)
+        val vurderingPdfService = VurderingPdfService(
+            externalMockEnvironment.pdfgenClient,
+            externalMockEnvironment.pdlClient,
+        )
+        val journalforingService = JournalforingService(
+            dokarkivClient = externalMockEnvironment.dokarkivClient,
+            pdlClient = externalMockEnvironment.pdlClient,
+            isJournalforingRetryEnabled = externalMockEnvironment.environment.isJournalforingRetryEnabled,
+        )
+
+        val mockVurderingProducer = mockk<KafkaProducer<String, VurderingRecord>>(relaxed = true)
+        val vurderingProducer = VurderingProducer(
+            producer = mockVurderingProducer,
+        )
+
+        val vurderingService = VurderingService(
+            vurderingRepository = vurderingRepository,
+            vurderingPdfService = vurderingPdfService,
+            journalforingService = journalforingService,
+            vurderingProducer = vurderingProducer,
+        )
+
+        beforeEachTest {
+            clearAllMocks()
+            coEvery { mockVurderingProducer.send(any()) } returns mockk<Future<RecordMetadata>>(relaxed = true)
+        }
+
+        afterEachTest {
+            database.dropData()
+        }
+
+        describe("RepublishForhandsvarselWithAdditionalInfoCronjob") {
+            val begrunnelse1 = "En begrunnelse1"
+            val svarfrist1 = LocalDate.of(2025, 3, 1)
+            val vurderingForhandsvarsel1 = generateForhandsvarselVurdering(
+                begrunnelse = begrunnelse1,
+                document = generateForhandsvarselRevarslingDocumentComponent(
+                    beskrivelse = begrunnelse1,
+                    svarfrist = svarfrist1,
+                ),
+                svarfrist = svarfrist1
+
+            )
+            val begrunnelse2 = "En begrunnelse2"
+            val svarfrist2 = LocalDate.of(2025, 3, 7)
+            val vurderingForhandsvarsel2 = generateForhandsvarselVurdering(
+                personident = ARBEIDSTAKER_2_PERSONIDENT,
+                begrunnelse = begrunnelse2,
+                document = generateForhandsvarselRevarslingDocumentComponent(
+                    beskrivelse = begrunnelse2,
+                    svarfrist = svarfrist2,
+                ),
+                svarfrist = svarfrist2
+            )
+
+            it("Henter gamle, overskriver teksten og svarfrist") {
+                val uuids = listOf(
+                    vurderingForhandsvarsel1.uuid.toString(),
+                    vurderingForhandsvarsel2.uuid.toString(),
+                )
+                val republishForhandsvarselWithAdditionalInfoCronjob = RepublishForhandsvarselWithAdditionalInfoCronjob(
+                    vurderingService = vurderingService,
+                    uuids = uuids,
+                )
+                vurderingRepository.createVurdering(
+                    pdf = PDF_FORHANDSVARSEL,
+                    vurdering = vurderingForhandsvarsel1,
+                )
+                vurderingRepository.createVurdering(
+                    pdf = PDF_FORHANDSVARSEL,
+                    vurdering = vurderingForhandsvarsel2,
+                )
+
+                runBlocking {
+                    val result = republishForhandsvarselWithAdditionalInfoCronjob.run()
+                    result.size shouldBeEqualTo 2
+                    result.forEach { it.isSuccess shouldBeEqualTo true }
+
+                    result[0].getOrThrow().begrunnelse shouldBeEqualTo begrunnelse1
+                    result[1].getOrThrow().begrunnelse shouldBeEqualTo begrunnelse2
+
+                    val vurderinger1 = vurderingRepository.getVurderinger(personident = vurderingForhandsvarsel1.personident)
+                    vurderinger1.size shouldBeEqualTo 2 // Har både nytt og gammelt varsel i databasen
+                    vurderinger1.all { it.type == VurderingType.FORHANDSVARSEL }.shouldBeTrue()
+                    vurderinger1.first().createdAt shouldBeGreaterThan vurderinger1.last().createdAt // Sortert DESC på created_at, så første er den nyeste
+                    vurderinger1.first().varsel?.svarfrist shouldBeEqualTo LocalDate.of(2025, 4, 7)
+                    vurderinger1.first().document.filter { documentComponent ->
+                        documentComponent.texts.contains(
+                            "OBS! På grunn av en teknisk feil på vår side, har vi ikke klart å varsle deg om dette brevet tidligere. Vi beklager ulempen. Vi har derfor forlenget fristen for å svare til 07.04.2025. Dette brevet er en eksakt kopi av det du skulle ha mottatt tidligere, men med ny utvidet frist."
+                        )
+                    }.size shouldBeEqualTo 1
+                    vurderinger1.first().document.filter { documentComponent ->
+                        documentComponent.texts.contains(
+                            svarfrist1.format(DateTimeFormatter.ofPattern("dd.MM.yyyy"))
+                        )
+                    }.size shouldBeEqualTo 0 // Inneholder ingen spor av gammel svarfrist
+                    vurderinger1.first().journalpostId shouldBeEqualTo null
+                    vurderinger1.first().publishedAt shouldBeEqualTo null
+                    vurderinger1.first().varsel?.publishedAt shouldBeEqualTo null
+
+                    val vurderinger2 = vurderingRepository.getVurderinger(personident = vurderingForhandsvarsel2.personident)
+                    vurderinger2.size shouldBeEqualTo 2 // Har både nytt og gammelt varsel i databasen
+                    vurderinger2.all { it.type == VurderingType.FORHANDSVARSEL }.shouldBeTrue()
+                    vurderinger2.first().createdAt shouldBeGreaterThan vurderinger2.last().createdAt // Sortert DESC på created_at, så første er den nyeste
+                    vurderinger2.first().varsel?.svarfrist shouldBeEqualTo LocalDate.of(2025, 4, 7)
+                    vurderinger2.first().document.filter { documentComponent ->
+                        documentComponent.texts.contains(
+                            "OBS! På grunn av en teknisk feil på vår side, har vi ikke klart å varsle deg om dette brevet tidligere. Vi beklager ulempen. Vi har derfor forlenget fristen for å svare til 07.04.2025. Dette brevet er en eksakt kopi av det du skulle ha mottatt tidligere, men med ny utvidet frist."
+                        )
+                    }.size shouldBeEqualTo 1
+                    vurderinger2.first().document.filter { documentComponent ->
+                        documentComponent.texts.contains(
+                            svarfrist1.format(DateTimeFormatter.ofPattern("dd.MM.yyyy"))
+                        )
+                    }.size shouldBeEqualTo 0 // Inneholder ingen spor av gammel svarfrist
+                    vurderinger2.first().journalpostId shouldBeEqualTo null
+                    vurderinger2.first().publishedAt shouldBeEqualTo null
+                    vurderinger2.first().varsel?.publishedAt shouldBeEqualTo null
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/no/nav/syfo/infrastructure/cronjob/RepublishForhandsvarselWithAdditionalInfoCronjobSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/cronjob/RepublishForhandsvarselWithAdditionalInfoCronjobSpek.kt
@@ -119,10 +119,10 @@ class RepublishForhandsvarselWithAdditionalInfoCronjobSpek : Spek({
                     vurderinger1.size shouldBeEqualTo 2 // Har både nytt og gammelt varsel i databasen
                     vurderinger1.all { it.type == VurderingType.FORHANDSVARSEL }.shouldBeTrue()
                     vurderinger1.first().createdAt shouldBeGreaterThan vurderinger1.last().createdAt // Sortert DESC på created_at, så første er den nyeste
-                    vurderinger1.first().varsel?.svarfrist shouldBeEqualTo LocalDate.of(2025, 4, 7)
+                    vurderinger1.first().varsel?.svarfrist shouldBeEqualTo LocalDate.of(2025, 4, 9)
                     vurderinger1.first().document.filter { documentComponent ->
                         documentComponent.texts.contains(
-                            "OBS! På grunn av en teknisk feil på vår side, har vi ikke klart å varsle deg om dette brevet tidligere. Vi beklager ulempen. Vi har derfor forlenget fristen for å svare til 07.04.2025. Dette brevet er en eksakt kopi av det du skulle ha mottatt tidligere, men med ny utvidet frist."
+                            "OBS! På grunn av en teknisk feil på vår side, har vi ikke klart å varsle deg om dette brevet tidligere. Vi beklager ulempen. Vi har derfor forlenget fristen for å svare til 09.04.2025. Dette brevet er en eksakt kopi av det du skulle ha mottatt tidligere, men med ny utvidet frist."
                         )
                     }.size shouldBeEqualTo 1
                     vurderinger1.first().document.filter { documentComponent ->
@@ -138,10 +138,10 @@ class RepublishForhandsvarselWithAdditionalInfoCronjobSpek : Spek({
                     vurderinger2.size shouldBeEqualTo 2 // Har både nytt og gammelt varsel i databasen
                     vurderinger2.all { it.type == VurderingType.FORHANDSVARSEL }.shouldBeTrue()
                     vurderinger2.first().createdAt shouldBeGreaterThan vurderinger2.last().createdAt // Sortert DESC på created_at, så første er den nyeste
-                    vurderinger2.first().varsel?.svarfrist shouldBeEqualTo LocalDate.of(2025, 4, 7)
+                    vurderinger2.first().varsel?.svarfrist shouldBeEqualTo LocalDate.of(2025, 4, 9)
                     vurderinger2.first().document.filter { documentComponent ->
                         documentComponent.texts.contains(
-                            "OBS! På grunn av en teknisk feil på vår side, har vi ikke klart å varsle deg om dette brevet tidligere. Vi beklager ulempen. Vi har derfor forlenget fristen for å svare til 07.04.2025. Dette brevet er en eksakt kopi av det du skulle ha mottatt tidligere, men med ny utvidet frist."
+                            "OBS! På grunn av en teknisk feil på vår side, har vi ikke klart å varsle deg om dette brevet tidligere. Vi beklager ulempen. Vi har derfor forlenget fristen for å svare til 09.04.2025. Dette brevet er en eksakt kopi av det du skulle ha mottatt tidligere, men med ny utvidet frist."
                         )
                     }.size shouldBeEqualTo 1
                     vurderinger2.first().document.filter { documentComponent ->

--- a/src/test/kotlin/no/nav/syfo/infrastructure/cronjob/RepublishForhandsvarselWithAdditionalInfoCronjobSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/cronjob/RepublishForhandsvarselWithAdditionalInfoCronjobSpek.kt
@@ -141,7 +141,8 @@ class RepublishForhandsvarselWithAdditionalInfoCronjobSpek : Spek({
                     vurderinger2.first().varsel?.svarfrist shouldBeEqualTo LocalDate.of(2025, 4, 9)
                     vurderinger2.first().document.filter { documentComponent ->
                         documentComponent.texts.contains(
-                            "Viktig informasjon: På grunn av en teknisk feil, har vi ikke klart å varsle deg om dette brevet tidligere. Vi beklager ulempen. På grunn av denne feilen mottar du derfor et nytt brev, med ny frist for tilbakemelding. Dette brevet erstatter tidligere brev som du ikke ble varslet om, og det er kun dette brevet du skal forholde deg til. Det opprinnelige brevet kan du finne under Mine dokumenter på innloggede sider på nav.no.\n"                        )
+                            "Viktig informasjon: På grunn av en teknisk feil, har vi ikke klart å varsle deg om dette brevet tidligere. Vi beklager ulempen. På grunn av denne feilen mottar du derfor et nytt brev, med ny frist for tilbakemelding. Dette brevet erstatter tidligere brev som du ikke ble varslet om, og det er kun dette brevet du skal forholde deg til. Det opprinnelige brevet kan du finne under Mine dokumenter på innloggede sider på nav.no.\n"
+                        )
                     }.size shouldBeEqualTo 1
                     vurderinger2.first().document.filter { documentComponent ->
                         documentComponent.texts.contains(

--- a/src/test/kotlin/no/nav/syfo/infrastructure/cronjob/RepublishForhandsvarselWithAdditionalInfoCronjobSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/cronjob/RepublishForhandsvarselWithAdditionalInfoCronjobSpek.kt
@@ -122,7 +122,7 @@ class RepublishForhandsvarselWithAdditionalInfoCronjobSpek : Spek({
                     vurderinger1.first().varsel?.svarfrist shouldBeEqualTo LocalDate.of(2025, 4, 9)
                     vurderinger1.first().document.filter { documentComponent ->
                         documentComponent.texts.contains(
-                            "OBS! På grunn av en teknisk feil på vår side, har vi ikke klart å varsle deg om dette brevet tidligere. Vi beklager ulempen. Vi har derfor forlenget fristen for å svare til 09.04.2025. Dette brevet er en eksakt kopi av det du skulle ha mottatt tidligere, men med ny utvidet frist."
+                            "Viktig informasjon: På grunn av en teknisk feil, har vi ikke klart å varsle deg om dette brevet tidligere. Vi beklager ulempen. På grunn av denne feilen mottar du derfor et nytt brev, med ny frist for tilbakemelding. Dette brevet erstatter tidligere brev som du ikke ble varslet om, og det er kun dette brevet du skal forholde deg til. Det opprinnelige brevet kan du finne under Mine dokumenter på innloggede sider på nav.no.\n"
                         )
                     }.size shouldBeEqualTo 1
                     vurderinger1.first().document.filter { documentComponent ->
@@ -141,8 +141,7 @@ class RepublishForhandsvarselWithAdditionalInfoCronjobSpek : Spek({
                     vurderinger2.first().varsel?.svarfrist shouldBeEqualTo LocalDate.of(2025, 4, 9)
                     vurderinger2.first().document.filter { documentComponent ->
                         documentComponent.texts.contains(
-                            "OBS! På grunn av en teknisk feil på vår side, har vi ikke klart å varsle deg om dette brevet tidligere. Vi beklager ulempen. Vi har derfor forlenget fristen for å svare til 09.04.2025. Dette brevet er en eksakt kopi av det du skulle ha mottatt tidligere, men med ny utvidet frist."
-                        )
+                            "Viktig informasjon: På grunn av en teknisk feil, har vi ikke klart å varsle deg om dette brevet tidligere. Vi beklager ulempen. På grunn av denne feilen mottar du derfor et nytt brev, med ny frist for tilbakemelding. Dette brevet erstatter tidligere brev som du ikke ble varslet om, og det er kun dette brevet du skal forholde deg til. Det opprinnelige brevet kan du finne under Mine dokumenter på innloggede sider på nav.no.\n"                        )
                     }.size shouldBeEqualTo 1
                     vurderinger2.first().document.filter { documentComponent ->
                         documentComponent.texts.contains(


### PR DESCRIPTION
Hva gjør den:
- Gitt uuider (som vi må finne på forhånd og legge inn i lista)
- Finn nåværende vurderinger
- Kopier over all info, bortsett fra `svarfrist` og `document`
- Skriv over `document` med nye datoer (3 steder)
- Legger på en ekstratekst under overskriften og før første setning: `OBS! ...`

Hva gjenstår:

- [x] Dobbeltsjekke `OBS`-tekst med Stine og co
- [x] Sette riktig fristdato
- [x] Teste i dev for noen uuider i databasen
- [x] Sjekke gosys at dokumentet som journalføres har riktige datoer
- [x] Toggle på i prod