### PR TITLE
IS-2777: Avslag uten forhåndsvarsel

### DIFF
--- a/src/main/kotlin/no/nav/syfo/application/service/VurderingService.kt
+++ b/src/main/kotlin/no/nav/syfo/application/service/VurderingService.kt
@@ -73,6 +73,13 @@ class VurderingService(
                 document = document,
                 gjelderFom = gjelderFom ?: throw IllegalArgumentException("gjelderFom is required for $type")
             )
+            VurderingType.AVSLAG_UTEN_FORHANDSVARSEL -> Vurdering.AvslagUtenForhandsvarsel(
+                personident = personident,
+                veilederident = veilederident,
+                begrunnelse = begrunnelse,
+                document = document,
+                gjelderFom = gjelderFom ?: throw IllegalArgumentException("gjelderFom is required for $type")
+            )
             VurderingType.IKKE_AKTUELL -> Vurdering.IkkeAktuell(
                 personident = personident,
                 veilederident = veilederident,
@@ -96,6 +103,7 @@ class VurderingService(
             VurderingType.OPPFYLT -> Metrics.COUNT_VURDERING_OPPFYLT.increment()
             VurderingType.OPPFYLT_UTEN_FORHANDSVARSEL -> Metrics.COUNT_VURDERING_OPPFYLT.increment()
             VurderingType.AVSLAG -> Metrics.COUNT_VURDERING_AVSLAG.increment()
+            VurderingType.AVSLAG_UTEN_FORHANDSVARSEL -> Metrics.COUNT_VURDERING_AVSLAG_UTEN_FORHANDSVARSEL.increment()
             VurderingType.IKKE_AKTUELL -> Metrics.COUNT_VURDERING_IKKE_AKTUELL.increment()
         }
 
@@ -143,6 +151,7 @@ private class Metrics {
         const val VURDERING_OPPFYLT = "${VURDERING_BASE}_oppfylt"
         const val VURDERING_OPPFYLT_UTEN_FORHANDSVARSEL = "${VURDERING_BASE}_oppfylt_uten_forhandsvarsel"
         const val VURDERING_AVSLAG = "${VURDERING_BASE}_avslag"
+        const val VURDERING_AVSLAG_UTEN_FORHANDSVARSEL = "${VURDERING_BASE}_avslag_uten_forhandsvarsel"
         const val VURDERING_IKKE_AKTUELL = "${VURDERING_BASE}_ikke_aktuell"
 
         val COUNT_VURDERING_FORHANDSVARSEL: Counter = Counter
@@ -160,6 +169,10 @@ private class Metrics {
         val COUNT_VURDERING_AVSLAG: Counter = Counter
             .builder(VURDERING_AVSLAG)
             .description("Counts the number of successful avslag vurderinger")
+            .register(METRICS_REGISTRY)
+        val COUNT_VURDERING_AVSLAG_UTEN_FORHANDSVARSEL: Counter = Counter
+            .builder(VURDERING_AVSLAG_UTEN_FORHANDSVARSEL)
+            .description("Counts the number of successful avslag uten forhandsvarsel vurderinger")
             .register(METRICS_REGISTRY)
         val COUNT_VURDERING_IKKE_AKTUELL: Counter = Counter
             .builder(VURDERING_IKKE_AKTUELL)

--- a/src/main/kotlin/no/nav/syfo/infrastructure/clients/pdfgen/VurderingPdfService.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/clients/pdfgen/VurderingPdfService.kt
@@ -30,7 +30,7 @@ class VurderingPdfService(
                 callId = callId,
                 vurderingPdfDTO = vurderingPdfDTO,
             )
-            VurderingType.AVSLAG -> pdfGenClient.createAvslagPdf(
+            VurderingType.AVSLAG, VurderingType.AVSLAG_UTEN_FORHANDSVARSEL -> pdfGenClient.createAvslagPdf(
                 callId = callId,
                 vurderingPdfDTO = vurderingPdfDTO,
             )

--- a/src/test/kotlin/no/nav/syfo/application/service/VurderingServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/application/service/VurderingServiceSpek.kt
@@ -102,6 +102,7 @@ class VurderingServiceSpek : Spek({
         val vurderingForhandsvarsel = generateForhandsvarselVurdering()
         val vurderingOppfylt = generateVurdering(type = VurderingType.OPPFYLT)
         val vurderingAvslag = generateVurdering(type = VurderingType.AVSLAG)
+        val vurderingAvslagUtenForhandsvarsel = generateVurdering(type = VurderingType.AVSLAG_UTEN_FORHANDSVARSEL)
         val vurderingIkkeAktuell = generateVurdering(type = VurderingType.IKKE_AKTUELL)
 
         describe("Journalføring") {
@@ -167,6 +168,25 @@ class VurderingServiceSpek : Spek({
 
                 val pVurdering = database.getVurdering(vurderingAvslag.uuid)
                 pVurdering!!.type shouldBeEqualTo VurderingType.AVSLAG.name
+                pVurdering.journalpostId shouldBeEqualTo mockedJournalpostId.toString()
+            }
+
+            it("journalfører AVSLAG_UTEN_FORHANDSVARSEL vurdering") {
+                vurderingRepository.createVurdering(
+                    vurdering = vurderingAvslagUtenForhandsvarsel,
+                    pdf = PDF_AVSLAG,
+                )
+
+                val journalforteVurderinger = runBlocking {
+                    vurderingService.journalforVurderinger()
+                }
+
+                val (success, failed) = journalforteVurderinger.partition { it.isSuccess }
+                failed.size shouldBeEqualTo 0
+                success.size shouldBeEqualTo 1
+
+                val pVurdering = database.getVurdering(vurderingAvslagUtenForhandsvarsel.uuid)
+                pVurdering!!.type shouldBeEqualTo VurderingType.AVSLAG_UTEN_FORHANDSVARSEL.name
                 pVurdering.journalpostId shouldBeEqualTo mockedJournalpostId.toString()
             }
 

--- a/src/test/kotlin/no/nav/syfo/generator/VurderingGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/generator/VurderingGenerator.kt
@@ -56,4 +56,11 @@ fun generateVurdering(
         document = document,
         gjelderFom = LocalDate.now(),
     )
+    VurderingType.AVSLAG_UTEN_FORHANDSVARSEL -> Vurdering.AvslagUtenForhandsvarsel(
+        personident = personident,
+        veilederident = UserConstants.VEILEDER_IDENT,
+        begrunnelse = begrunnelse,
+        document = document,
+        gjelderFom = LocalDate.now(),
+    )
 }


### PR DESCRIPTION
Backend skal tillate registrering av avslag uten at det tidligere er gjort en forhåndsvarsling. Innfører egen vurderingstype for dette.