### PR TITLE
IS-3337: Add initiertav to avslag uten forhandsvarsel vurdering

### DIFF
--- a/src/main/kotlin/no/nav/syfo/api/endpoints/ArbeidsuforhetEndpoints.kt
+++ b/src/main/kotlin/no/nav/syfo/api/endpoints/ArbeidsuforhetEndpoints.kt
@@ -67,6 +67,7 @@ fun Route.registerArbeidsuforhetEndpoints(
                     document = requestDTO.document,
                     gjelderFom = requestDTO.gjelderFom,
                     svarfrist = requestDTO.frist,
+                    vurderingInitiertAv = requestDTO.vurderingInitiertAv,
                     oppgaveFraNayDato = requestDTO.oppgaveFraNayDato,
                     callId = callId,
                 )

--- a/src/main/kotlin/no/nav/syfo/api/model/VurderingRequestDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/api/model/VurderingRequestDTO.kt
@@ -1,6 +1,7 @@
 package no.nav.syfo.api.model
 
 import no.nav.syfo.domain.DocumentComponent
+import no.nav.syfo.domain.Vurdering.AvslagUtenForhandsvarsel.VurderingInitiertAv
 import no.nav.syfo.domain.VurderingArsak
 import no.nav.syfo.domain.VurderingType
 import java.time.LocalDate
@@ -12,5 +13,6 @@ data class VurderingRequestDTO(
     val gjelderFom: LocalDate? = null,
     val arsak: VurderingArsak? = null,
     val frist: LocalDate? = null,
+    val vurderingInitiertAv: VurderingInitiertAv? = null,
     val oppgaveFraNayDato: LocalDate? = null,
 )

--- a/src/main/kotlin/no/nav/syfo/api/model/VurderingResponseDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/api/model/VurderingResponseDTO.kt
@@ -1,9 +1,10 @@
 package no.nav.syfo.api.model
 
 import no.nav.syfo.domain.*
+import no.nav.syfo.domain.Vurdering.AvslagUtenForhandsvarsel.VurderingInitiertAv
 import java.time.LocalDate
 import java.time.LocalDateTime
-import java.util.UUID
+import java.util.*
 
 data class VurderingResponseDTO private constructor(
     val uuid: UUID,
@@ -16,6 +17,7 @@ data class VurderingResponseDTO private constructor(
     val document: List<DocumentComponent>,
     val varsel: VarselDTO?,
     val gjelderFom: LocalDate?,
+    val vurderingInitiertAv: VurderingInitiertAv?,
     val oppgaveFraNayDato: LocalDate?,
 ) {
     companion object {
@@ -30,6 +32,7 @@ data class VurderingResponseDTO private constructor(
             document = vurdering.document,
             varsel = vurdering.varsel?.let { VarselDTO.createFromVarsel(it) },
             gjelderFom = vurdering.gjelderFom,
+            vurderingInitiertAv = if (vurdering is Vurdering.AvslagUtenForhandsvarsel) vurdering.vurderingInitiertAv else null,
             oppgaveFraNayDato = vurdering.oppgaveFraNayDato(),
         )
     }

--- a/src/main/kotlin/no/nav/syfo/domain/Vurdering.kt
+++ b/src/main/kotlin/no/nav/syfo/domain/Vurdering.kt
@@ -51,7 +51,19 @@ sealed class Vurdering(
         override val varsel: Varsel,
         override val journalpostId: JournalpostId? = null,
         override val publishedAt: OffsetDateTime? = null
-    ) : Vurdering(uuid, createdAt, personident, veilederident, VurderingType.FORHANDSVARSEL, begrunnelse, varsel, document, journalpostId, publishedAt, null) {
+    ) : Vurdering(
+        uuid,
+        createdAt,
+        personident,
+        veilederident,
+        VurderingType.FORHANDSVARSEL,
+        begrunnelse,
+        varsel,
+        document,
+        journalpostId,
+        publishedAt,
+        null
+    ) {
 
         constructor(
             personident: PersonIdent,
@@ -79,7 +91,19 @@ sealed class Vurdering(
         override val document: List<DocumentComponent>,
         override val journalpostId: JournalpostId? = null,
         override val publishedAt: OffsetDateTime? = null
-    ) : Vurdering(uuid, createdAt, personident, veilederident, VurderingType.OPPFYLT, begrunnelse, null, document, journalpostId, publishedAt, null) {
+    ) : Vurdering(
+        uuid,
+        createdAt,
+        personident,
+        veilederident,
+        VurderingType.OPPFYLT,
+        begrunnelse,
+        null,
+        document,
+        journalpostId,
+        publishedAt,
+        null
+    ) {
 
         constructor(
             personident: PersonIdent,
@@ -105,16 +129,26 @@ sealed class Vurdering(
         override val document: List<DocumentComponent>,
         override val journalpostId: JournalpostId? = null,
         override val publishedAt: OffsetDateTime? = null,
-        val arsak: Arsak,
         val oppgaveFraNayDato: LocalDate? = null,
-    ) : Vurdering(uuid, createdAt, personident, veilederident, VurderingType.OPPFYLT_UTEN_FORHANDSVARSEL, begrunnelse, null, document, journalpostId, publishedAt, null) {
+    ) : Vurdering(
+        uuid,
+        createdAt,
+        personident,
+        veilederident,
+        VurderingType.OPPFYLT_UTEN_FORHANDSVARSEL,
+        begrunnelse,
+        null,
+        document,
+        journalpostId,
+        publishedAt,
+        null
+    ) {
 
         constructor(
             personident: PersonIdent,
             veilederident: String,
             begrunnelse: String,
             document: List<DocumentComponent>,
-            arsak: Arsak,
             oppgaveFraNayDato: LocalDate?,
         ) : this(
             personident = personident,
@@ -123,14 +157,8 @@ sealed class Vurdering(
             document = document,
             journalpostId = null,
             publishedAt = null,
-            arsak = arsak,
             oppgaveFraNayDato = oppgaveFraNayDato,
         )
-
-        enum class Arsak {
-            SYKEPENGER_IKKE_UTBETALT,
-            NAY_BER_OM_NY_VURDERING,
-        }
     }
 
     data class Avslag internal constructor(
@@ -143,7 +171,19 @@ sealed class Vurdering(
         override val gjelderFom: LocalDate,
         override val journalpostId: JournalpostId? = null,
         override val publishedAt: OffsetDateTime? = null
-    ) : Vurdering(uuid, createdAt, personident, veilederident, VurderingType.AVSLAG, begrunnelse, null, document, journalpostId, publishedAt, gjelderFom) {
+    ) : Vurdering(
+        uuid,
+        createdAt,
+        personident,
+        veilederident,
+        VurderingType.AVSLAG,
+        begrunnelse,
+        null,
+        document,
+        journalpostId,
+        publishedAt,
+        gjelderFom
+    ) {
 
         constructor(
             personident: PersonIdent,
@@ -172,9 +212,21 @@ sealed class Vurdering(
         override val gjelderFom: LocalDate,
         override val journalpostId: JournalpostId? = null,
         override val publishedAt: OffsetDateTime? = null,
-        val arsak: Arsak,
+        val vurderingInitiertAv: VurderingInitiertAv,
         val oppgaveFraNayDato: LocalDate? = null,
-    ) : Vurdering(uuid, createdAt, personident, veilederident, VurderingType.AVSLAG_UTEN_FORHANDSVARSEL, begrunnelse, null, document, journalpostId, publishedAt, gjelderFom) {
+    ) : Vurdering(
+        uuid,
+        createdAt,
+        personident,
+        veilederident,
+        VurderingType.AVSLAG_UTEN_FORHANDSVARSEL,
+        begrunnelse,
+        null,
+        document,
+        journalpostId,
+        publishedAt,
+        gjelderFom
+    ) {
 
         constructor(
             personident: PersonIdent,
@@ -182,7 +234,7 @@ sealed class Vurdering(
             begrunnelse: String,
             document: List<DocumentComponent>,
             gjelderFom: LocalDate,
-            arsak: Arsak,
+            vurderingInitiertAv: VurderingInitiertAv,
             oppgaveFraNayDato: LocalDate?,
         ) : this(
             personident = personident,
@@ -192,13 +244,13 @@ sealed class Vurdering(
             gjelderFom = gjelderFom,
             journalpostId = null,
             publishedAt = null,
-            arsak = arsak,
+            vurderingInitiertAv = vurderingInitiertAv,
             oppgaveFraNayDato = oppgaveFraNayDato,
         )
 
-        enum class Arsak {
-            SYKEPENGER_IKKE_UTBETALT,
-            NAY_BER_OM_NY_VURDERING,
+        enum class VurderingInitiertAv {
+            NAV_KONTOR,
+            NAY,
         }
     }
 
@@ -211,7 +263,19 @@ sealed class Vurdering(
         override val journalpostId: JournalpostId? = null,
         override val publishedAt: OffsetDateTime? = null,
         val arsak: Arsak,
-    ) : Vurdering(uuid, createdAt, personident, veilederident, VurderingType.IKKE_AKTUELL, "", null, document, journalpostId, publishedAt, null) {
+    ) : Vurdering(
+        uuid,
+        createdAt,
+        personident,
+        veilederident,
+        VurderingType.IKKE_AKTUELL,
+        "",
+        null,
+        document,
+        journalpostId,
+        publishedAt,
+        null
+    ) {
 
         constructor(
             personident: PersonIdent,
@@ -247,6 +311,7 @@ sealed class Vurdering(
             varsel: Varsel?,
             publishedAt: OffsetDateTime?,
             gjelderFom: LocalDate?,
+            vurderingInitiertAv: AvslagUtenForhandsvarsel.VurderingInitiertAv?,
             oppgaveFraNayDato: LocalDate?,
         ): Vurdering {
             return when (VurderingType.valueOf(type)) {
@@ -278,7 +343,6 @@ sealed class Vurdering(
                     createdAt = createdAt,
                     personident = personident,
                     veilederident = veilederident,
-                    arsak = OppfyltUtenForhandsvarsel.Arsak.valueOf(arsak!!),
                     begrunnelse = begrunnelse,
                     document = document,
                     journalpostId = journalpostId,
@@ -303,12 +367,12 @@ sealed class Vurdering(
                     createdAt = createdAt,
                     personident = personident,
                     veilederident = veilederident,
-                    arsak = AvslagUtenForhandsvarsel.Arsak.valueOf(arsak!!),
                     begrunnelse = begrunnelse,
                     document = document,
                     gjelderFom = gjelderFom!!,
                     journalpostId = journalpostId,
                     publishedAt = publishedAt,
+                    vurderingInitiertAv = vurderingInitiertAv!!,
                     oppgaveFraNayDato = oppgaveFraNayDato,
                 )
 
@@ -328,8 +392,6 @@ sealed class Vurdering(
 
     fun arsak(): String? =
         when (this) {
-            is OppfyltUtenForhandsvarsel -> arsak.name
-            is AvslagUtenForhandsvarsel -> arsak.name
             is IkkeAktuell -> arsak.name
             else -> null
         }

--- a/src/main/kotlin/no/nav/syfo/domain/VurderingArsak.kt
+++ b/src/main/kotlin/no/nav/syfo/domain/VurderingArsak.kt
@@ -3,6 +3,4 @@ package no.nav.syfo.domain
 enum class VurderingArsak {
     FRISKMELDT,
     FRISKMELDING_TIL_ARBEIDSFORMIDLING,
-    SYKEPENGER_IKKE_UTBETALT,
-    NAY_BER_OM_NY_VURDERING,
 }

--- a/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/PVurdering.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/PVurdering.kt
@@ -1,9 +1,14 @@
 package no.nav.syfo.infrastructure.database.repository
 
-import no.nav.syfo.domain.*
+import no.nav.syfo.domain.DocumentComponent
+import no.nav.syfo.domain.JournalpostId
+import no.nav.syfo.domain.PersonIdent
+import no.nav.syfo.domain.Varsel
+import no.nav.syfo.domain.Vurdering
+import no.nav.syfo.domain.Vurdering.AvslagUtenForhandsvarsel.VurderingInitiertAv
 import java.time.LocalDate
 import java.time.OffsetDateTime
-import java.util.UUID
+import java.util.*
 
 data class PVurdering(
     val id: Int,
@@ -19,6 +24,7 @@ data class PVurdering(
     val journalpostId: String?,
     val publishedAt: OffsetDateTime?,
     val gjelderFom: LocalDate?,
+    val vurderingInitiertAv: VurderingInitiertAv?,
     val oppgaveFraNayDato: LocalDate?,
 ) {
 
@@ -37,6 +43,7 @@ data class PVurdering(
         varsel = varsel,
         publishedAt = publishedAt,
         gjelderFom = gjelderFom,
+        vurderingInitiertAv = vurderingInitiertAv,
         oppgaveFraNayDato = oppgaveFraNayDato,
     )
 }

--- a/src/test/kotlin/no/nav/syfo/generator/VurderingGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/generator/VurderingGenerator.kt
@@ -1,7 +1,10 @@
 package no.nav.syfo.generator
 
 import no.nav.syfo.UserConstants
-import no.nav.syfo.domain.*
+import no.nav.syfo.domain.DocumentComponent
+import no.nav.syfo.domain.PersonIdent
+import no.nav.syfo.domain.Vurdering
+import no.nav.syfo.domain.VurderingType
 import java.time.LocalDate
 
 fun generateForhandsvarselVurdering(
@@ -31,25 +34,28 @@ fun generateVurdering(
         document = document,
         svarfrist = svarfrist!!,
     )
+
     VurderingType.IKKE_AKTUELL -> Vurdering.IkkeAktuell(
         personident = personident,
         veilederident = UserConstants.VEILEDER_IDENT,
         arsak = Vurdering.IkkeAktuell.Arsak.FRISKMELDT,
         document = document,
     )
+
     VurderingType.OPPFYLT -> Vurdering.Oppfylt(
         personident = personident,
         veilederident = UserConstants.VEILEDER_IDENT,
         begrunnelse = begrunnelse,
         document = document,
     )
+
     VurderingType.OPPFYLT_UTEN_FORHANDSVARSEL -> Vurdering.OppfyltUtenForhandsvarsel(
         personident = personident,
         veilederident = UserConstants.VEILEDER_IDENT,
-        arsak = Vurdering.OppfyltUtenForhandsvarsel.Arsak.NAY_BER_OM_NY_VURDERING,
         begrunnelse = begrunnelse,
         document = document,
     )
+
     VurderingType.AVSLAG -> Vurdering.Avslag(
         personident = personident,
         veilederident = UserConstants.VEILEDER_IDENT,
@@ -57,13 +63,14 @@ fun generateVurdering(
         document = document,
         gjelderFom = LocalDate.now(),
     )
+
     VurderingType.AVSLAG_UTEN_FORHANDSVARSEL -> Vurdering.AvslagUtenForhandsvarsel(
         personident = personident,
         veilederident = UserConstants.VEILEDER_IDENT,
-        arsak = Vurdering.AvslagUtenForhandsvarsel.Arsak.NAY_BER_OM_NY_VURDERING,
         begrunnelse = begrunnelse,
         document = document,
         gjelderFom = LocalDate.now(),
+        vurderingInitiertAv = Vurdering.AvslagUtenForhandsvarsel.VurderingInitiertAv.NAV_KONTOR,
         oppgaveFraNayDato = LocalDate.now().minusDays(1),
     )
 }


### PR DESCRIPTION
- Legger til `vurderingInitiertAv` som en verdi som må være satt på en `AvslagUtenForhandsvarsel` vurdering.

- [x] Gjenstår å få det til å fungere med ny databasekolonne

Se [PR som legger til kolonne i db](https://github.com/navikt/isarbeidsuforhet/pull/159)
Se [PR som gjør nødvendige frontend endringer](https://github.com/navikt/syfomodiaperson/pull/1731)