### PR TITLE
IS-3337-2: Add vurdering_initiert_av column

### DIFF
--- a/src/main/resources/db/migration/V2_6__add_column_vurdering_initiert_av.sql
+++ b/src/main/resources/db/migration/V2_6__add_column_vurdering_initiert_av.sql
@@ -1,0 +1,1 @@
+ALTER TABLE VURDERING ADD COLUMN vurdering_initiert_av TEXT;


### PR DESCRIPTION
- Legger til `vurdering_initiert_av` kolonne

Se [relatert PR](https://github.com/navikt/isarbeidsuforhet/pull/158) i `isarbeidsuforhet` som implementerer bruk av kolonnen
Ses i sammenheng med [denne PR'en](https://github.com/navikt/syfomodiaperson/pull/1731) i `syfomodiaperson`