### PR TITLE
IS-3378: OPPFYLT_UTEN_FORHANDSVARSEL journalfores som NOTAT og ikke U…

### DIFF
--- a/src/main/kotlin/no/nav/syfo/infrastructure/clients/dokarkiv/dto/JournalpostRequest.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/clients/dokarkiv/dto/JournalpostRequest.kt
@@ -2,6 +2,11 @@ package no.nav.syfo.infrastructure.clients.dokarkiv.dto
 
 const val JOURNALFORENDE_ENHET = 9999
 
+/**
+ * UTGAAENDE brukes for dokumentasjon som NAV har produsert og sendt ut til en ekstern part. Dette kan for eksempel være informasjons- eller vedtaksbrev til privatpersoner eller organisasjoner.
+ *
+ * NOTAT brukes for dokumentasjon som NAV har produsert selv og uten mål om å distribuere dette ut av NAV. Eksempler på dette er forvaltningsnotater og referater fra telefonsamtaler med brukere.
+ */
 enum class JournalpostType {
     UTGAAENDE,
     NOTAT,

--- a/src/main/kotlin/no/nav/syfo/infrastructure/journalforing/JournalforingService.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/journalforing/JournalforingService.kt
@@ -45,7 +45,7 @@ class JournalforingService(
         pdf: ByteArray,
         vurdering: Vurdering,
     ): JournalpostRequest {
-        val journalpostType = vurdering.type.getJournalpostType()
+        val journalpostType = vurdering.journalpostType
         val avsenderMottaker = if (journalpostType != JournalpostType.NOTAT) {
             AvsenderMottaker.create(
                 id = personIdent.value,


### PR DESCRIPTION
- Setter `OPPFYLT_UTEN_FORHANDSVARSEL` som `NOTAT` og ikke `UTGAAENDE` ettersom bruker ikke trenger å se denne vurderingen.
- Prøver også å knytte `journalpostType` tettere domene ved å legge det inn som en krevd property på hver subtype av `Vurdering`. Tanker om dette? 😊

Se [tilhørende PR](https://github.com/navikt/syfomodiaperson/pull/1763) i `syfomodiaperson`

Stusser over flere av typene her 🤔
Burde ikke begge avslagene være `UTGAAENDE`?

Disse er nå satt til `JournalpostType.UTGAAENDE`
```
VurderingType.FORHANDSVARSEL, 
VurderingType.OPPFYLT, 
VurderingType.IKKE_AKTUELL
```
og disse er satt til `JournalpostType.NOTAT`
```
VurderingType.AVSLAG
VurderingType.AVSLAG_UTEN_FORHANDSVARSEL
VurderingType.OPPFYLT_UTEN_FORHANDSVARSEL
```