### PR TITLE
IS-3414: Minor refactor Vurdering

### DIFF
--- a/src/main/kotlin/no/nav/syfo/domain/Vurdering.kt
+++ b/src/main/kotlin/no/nav/syfo/domain/Vurdering.kt
@@ -19,6 +19,8 @@ sealed class Vurdering(
     open val publishedAt: OffsetDateTime?,
 ) {
     abstract val journalpostType: JournalpostType
+    abstract val brevkode: BrevkodeType
+    abstract val dokumentTittel: String
 
     fun journalfor(journalpostId: JournalpostId): Vurdering = when (this) {
         is Forhandsvarsel -> this.copy(journalpostId = journalpostId)
@@ -76,6 +78,8 @@ sealed class Vurdering(
         publishedAt,
     ) {
         override val journalpostType: JournalpostType = JournalpostType.UTGAAENDE
+        override val brevkode: BrevkodeType = BrevkodeType.ARBEIDSUFORHET_FORHANDSVARSEL
+        override val dokumentTittel: String = "Forhåndsvarsel om avslag på sykepenger"
 
         constructor(
             personident: PersonIdent,
@@ -115,6 +119,8 @@ sealed class Vurdering(
         publishedAt,
     ) {
         override val journalpostType: JournalpostType = JournalpostType.UTGAAENDE
+        override val brevkode: BrevkodeType = BrevkodeType.ARBEIDSUFORHET_VURDERING
+        override val dokumentTittel: String = "Vurdering av § 8-4 arbeidsuførhet"
 
         constructor(
             personident: PersonIdent,
@@ -153,6 +159,8 @@ sealed class Vurdering(
         publishedAt,
     ) {
         override val journalpostType: JournalpostType = JournalpostType.NOTAT
+        override val brevkode: BrevkodeType = BrevkodeType.ARBEIDSUFORHET_VURDERING
+        override val dokumentTittel: String = "Vurdering av § 8-4 arbeidsuførhet"
 
         constructor(
             personident: PersonIdent,
@@ -196,6 +204,8 @@ sealed class Vurdering(
          * `Vurdering.Avslag` har JournalpostType.NOTAT fordi NAY har vedtaksmyndighet og det er de som skal sende ut selve vedtaket.
          */
         override val journalpostType: JournalpostType = JournalpostType.NOTAT
+        override val brevkode: BrevkodeType = BrevkodeType.ARBEIDSUFORHET_AVSLAG
+        override val dokumentTittel = "Innstilling om avslag"
 
         constructor(
             personident: PersonIdent,
@@ -241,6 +251,8 @@ sealed class Vurdering(
          * `Vurdering.AvslagUtenForhandsvarsel` har JournalpostType.NOTAT fordi NAY har vedtaksmyndighet og det er de som skal sende ut selve vedtaket.
          */
         override val journalpostType: JournalpostType = JournalpostType.NOTAT
+        override val brevkode: BrevkodeType = BrevkodeType.ARBEIDSUFORHET_AVSLAG
+        override val dokumentTittel: String = "Innstilling om avslag"
 
         constructor(
             personident: PersonIdent,
@@ -289,6 +301,8 @@ sealed class Vurdering(
         publishedAt,
     ) {
         override val journalpostType: JournalpostType = JournalpostType.UTGAAENDE
+        override val brevkode: BrevkodeType = BrevkodeType.ARBEIDSUFORHET_VURDERING
+        override val dokumentTittel: String = "Vurdering av § 8-4 arbeidsuførhet"
 
         constructor(
             personident: PersonIdent,
@@ -411,16 +425,4 @@ enum class VurderingType(val isFinal: Boolean) {
     AVSLAG(true),
     AVSLAG_UTEN_FORHANDSVARSEL(true),
     IKKE_AKTUELL(true);
-}
-
-fun VurderingType.getDokumentTittel(): String = when (this) {
-    VurderingType.FORHANDSVARSEL -> "Forhåndsvarsel om avslag på sykepenger"
-    VurderingType.OPPFYLT, VurderingType.OPPFYLT_UTEN_FORHANDSVARSEL, VurderingType.IKKE_AKTUELL -> "Vurdering av §8-4 arbeidsuførhet"
-    VurderingType.AVSLAG, VurderingType.AVSLAG_UTEN_FORHANDSVARSEL -> "Innstilling om avslag"
-}
-
-fun VurderingType.getBrevkode(): BrevkodeType = when (this) {
-    VurderingType.FORHANDSVARSEL -> BrevkodeType.ARBEIDSUFORHET_FORHANDSVARSEL
-    VurderingType.OPPFYLT, VurderingType.OPPFYLT_UTEN_FORHANDSVARSEL, VurderingType.IKKE_AKTUELL -> BrevkodeType.ARBEIDSUFORHET_VURDERING
-    VurderingType.AVSLAG, VurderingType.AVSLAG_UTEN_FORHANDSVARSEL -> BrevkodeType.ARBEIDSUFORHET_AVSLAG
 }

--- a/src/main/kotlin/no/nav/syfo/infrastructure/journalforing/JournalforingService.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/journalforing/JournalforingService.kt
@@ -59,26 +59,24 @@ class JournalforingService(
             idType = BrukerIdType.PERSON_IDENT,
         )
 
-        val dokumentTittel = vurdering.type.getDokumentTittel()
-
         val dokumenter = listOf(
             Dokument.create(
-                brevkode = vurdering.type.getBrevkode(),
+                brevkode = vurdering.brevkode,
                 dokumentvarianter = listOf(
                     Dokumentvariant.create(
-                        filnavn = dokumentTittel,
+                        filnavn = vurdering.dokumentTittel,
                         filtype = FiltypeType.PDFA,
                         fysiskDokument = pdf,
                         variantformat = VariantformatType.ARKIV,
                     )
                 ),
-                tittel = dokumentTittel,
+                tittel = vurdering.dokumentTittel,
             )
         )
         return JournalpostRequest(
             journalpostType = journalpostType.name,
             avsenderMottaker = avsenderMottaker,
-            tittel = dokumentTittel,
+            tittel = vurdering.dokumentTittel,
             bruker = bruker,
             dokumenter = dokumenter,
             eksternReferanseId = vurdering.uuid.toString(),

--- a/src/test/kotlin/no/nav/syfo/infrastructure/journalforing/JournalforingServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/infrastructure/journalforing/JournalforingServiceSpek.kt
@@ -55,7 +55,7 @@ object JournalforingServiceSpek : Spek({
                 coVerify(exactly = 1) {
                     dokarkivMock.journalfor(
                         journalpostRequest = generateJournalpostRequest(
-                            tittel = "Vurdering av §8-4 arbeidsuførhet",
+                            tittel = "Vurdering av § 8-4 arbeidsuførhet",
                             brevkodeType = BrevkodeType.ARBEIDSUFORHET_VURDERING,
                             pdf = PDF_VURDERING,
                             vurderingUuid = vurderingOppfylt.uuid,
@@ -130,7 +130,7 @@ object JournalforingServiceSpek : Spek({
                 coVerify(exactly = 1) {
                     dokarkivMock.journalfor(
                         journalpostRequest = generateJournalpostRequest(
-                            tittel = "Vurdering av §8-4 arbeidsuførhet",
+                            tittel = "Vurdering av § 8-4 arbeidsuførhet",
                             brevkodeType = BrevkodeType.ARBEIDSUFORHET_VURDERING,
                             pdf = PDF_VURDERING,
                             vurderingUuid = vurderingIkkeAktuell.uuid,


### PR DESCRIPTION
Litt refactor i forbindelse med `IS-3414` – som egentlig ikke krever noen endringer i `isarbeidsuforhet`, men var innom å ryddet litt.

- Tenker det er bedre at disse verdiene ligger på selve klassen enn å ha en funksjon som typesjekker `type` propertien for å så returnere verdien som kanskje bare burde eksistert på klassen i utgangspunktet.
- Lurer også på om vi burde trekke inn journalpost klasser som `JournalpostRequest` siden journalføring ligger så tett til forretningslogikken 🤔 Selve klienten og detaljer rundt utsending vil fortsatt ligge i `infrastructure`.

Tanker om disse? 👆😊