### PR TITLE
IS: Add workflow dispatch for manual trigger of deploy-workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,6 +1,8 @@
 name: main
 
-on: push
+on:
+  push:
+  workflow_dispatch:
 
 jobs:
   build-and-deploy:


### PR DESCRIPTION
Som er gjort i de andre appene. Brukes for å trigge ny deploy til main uten å måtte gjøre endringer, og på den måten hente inn nye chainguard images.